### PR TITLE
Fix crash due to misuse of PySequence_Fast_GET_ITEM

### DIFF
--- a/src/cares.c
+++ b/src/cares.c
@@ -1273,7 +1273,6 @@ set_nameservers(Channel *self, PyObject *value)
             Py_XDECREF(item);
             goto end;
         }
-        Py_DECREF(item);
         server = pbuf.buf;
 
         if (ares_inet_pton(AF_INET, server, &servers[i].addr.addr4) == 1) {


### PR DESCRIPTION
When nameservers are set, cPySequence_Fast_GET_ITEM is used to get
elements from the nameservers list. This function does not increment the
reference counter!  This causes the Python garbage collector to crash
when called...
