### PR TITLE
setup: Fix decoding in non-UTF-8 environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from distutils.core import setup, Extension
 from setup_cares import cares_build_ext
-
+import codecs
 
 __version__ = "0.6.3"
 
@@ -12,7 +12,7 @@ setup(name             = "pycares",
       author_email     = "saghul@gmail.com",
       url              = "http://github.com/saghul/pycares",
       description      = "Python interface for c-ares",
-      long_description = open("README.rst").read(),
+      long_description = codecs.open("README.rst", encoding="utf-8").read(),
       platforms        = ["POSIX", "Microsoft Windows"],
       classifiers      = [
           "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I have been hitting this issue while packaging pycares for Exherbo:
all our builds are done in sandboxes where LANG=C

Note that this fix is for Python 3 only.
As I'm not a Python developer, I will let you find a solution compatible with 2.7
