### PR TITLE
Updated the build process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
+sudo: false
 python:
   - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
   - python setup.py install
 script:
   - ./tests.py


### PR DESCRIPTION
Added Python 3.4 to the build.
Used travis_retry instead of --use-mirrors since that option is deprecated.
Used travis' new build workers since they boot up faster and since the project does not require sudo access.