### PR TITLE
pycares: register result struct-sequences in pycares, ruggedize UTs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-# coding=utf-8
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from setuptools import setup, Extension
 from setup_cares import cares_build_ext

--- a/src/pycares.c
+++ b/src/pycares.c
@@ -101,28 +101,50 @@ init_pycares(void)
     PyCaresModule_AddType(pycares, "AresError", (PyTypeObject *)PyExc_AresError);
 
     /* Initialize PyStructSequence types */
-    if (AresHostResultType.tp_name == 0)
+    if (AresHostResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresHostResultType, &ares_host_result_desc);
-    if (AresNameinfoResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_host_result", &AresHostResultType);
+    }
+    if (AresNameinfoResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresNameinfoResultType, &ares_nameinfo_result_desc);
-    if (AresQuerySimpleResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_nameinfo_result", &AresNameinfoResultType);
+    }
+    if (AresQuerySimpleResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQuerySimpleResultType, &ares_query_simple_result_desc);
-    if (AresQueryCNAMEResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_simple_result", &AresQuerySimpleResultType);
+    }
+    if (AresQueryCNAMEResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQueryCNAMEResultType, &ares_query_cname_result_desc);
-    if (AresQueryMXResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_cname_result", &AresQueryCNAMEResultType);
+    }
+    if (AresQueryMXResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQueryMXResultType, &ares_query_mx_result_desc);
-    if (AresQueryNSResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_mx_result", &AresQueryMXResultType);
+    }
+    if (AresQueryNSResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQueryNSResultType, &ares_query_ns_result_desc);
-    if (AresQueryPTRResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_ns_result", &AresQueryNSResultType);
+    }
+    if (AresQueryPTRResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQueryPTRResultType, &ares_query_ptr_result_desc);
-    if (AresQuerySOAResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_ptr_result", &AresQueryPTRResultType);
+    }
+    if (AresQuerySOAResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQuerySOAResultType, &ares_query_soa_result_desc);
-    if (AresQuerySRVResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_soa_result", &AresQuerySOAResultType);
+    }
+    if (AresQuerySRVResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQuerySRVResultType, &ares_query_srv_result_desc);
-    if (AresQueryTXTResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_srv_result", &AresQuerySRVResultType);
+    }
+    if (AresQueryTXTResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQueryTXTResultType, &ares_query_txt_result_desc);
-    if (AresQueryNAPTRResultType.tp_name == 0)
+        PyCaresModule_AddType(pycares, "ares_query_txt_result", &AresQueryTXTResultType);
+    }
+    if (AresQueryNAPTRResultType.tp_name == 0) {
         PyStructSequence_InitType(&AresQueryNAPTRResultType, &ares_query_naptr_result_desc);
+        PyCaresModule_AddType(pycares, "ares_query_naptr_result", &AresQueryNAPTRResultType);
+    }
 
     /* Flag values */
     PyModule_AddIntMacro(pycares, ARES_FLAG_USEVC);

--- a/tests.py
+++ b/tests.py
@@ -39,6 +39,7 @@ class DNSTest(unittest.TestCase):
         self.channel.gethostbyaddr('127.0.0.1', cb)
         self.wait()
         self.assertEqual(self.errorno, None)
+        self.assertEqual(type(self.result), pycares.ares_host_result)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyaddr6(self):
@@ -48,6 +49,7 @@ class DNSTest(unittest.TestCase):
         self.channel.gethostbyaddr('::1', cb)
         self.wait()
         self.assertEqual(self.errorno, None)
+        self.assertEqual(type(self.result), pycares.ares_host_result)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyname(self):
@@ -57,6 +59,7 @@ class DNSTest(unittest.TestCase):
         self.channel.gethostbyname('localhost', socket.AF_INET, cb)
         self.wait()
         self.assertEqual(self.errorno, None)
+        self.assertEqual(type(self.result), pycares.ares_host_result)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyname_small_timeout(self):
@@ -67,6 +70,7 @@ class DNSTest(unittest.TestCase):
         self.channel.gethostbyname('localhost', socket.AF_INET, cb)
         self.wait()
         self.assertEqual(self.errorno, None)
+        self.assertEqual(type(self.result), pycares.ares_host_result)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_getnameinfo(self):
@@ -76,6 +80,7 @@ class DNSTest(unittest.TestCase):
         self.channel.getnameinfo(('127.0.0.1', 80), pycares.ARES_NI_LOOKUPHOST|pycares.ARES_NI_LOOKUPSERVICE, cb)
         self.wait()
         self.assertEqual(self.errorno, None)
+        self.assertEqual(type(self.result), pycares.ares_nameinfo_result)
         self.assertIn(self.result[0], ('localhost.localdomain', 'localhost'))
         self.assertEqual(self.result[1], 'http')
 
@@ -87,6 +92,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(self.errorno, None)
         for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_simple_result)
             self.assertNotEqual(r.host, None)
             self.assertTrue(r.ttl >= 0)
 
@@ -123,6 +129,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(self.errorno, None)
         for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_simple_result)
             self.assertNotEqual(r.host, None)
             self.assertTrue(r.ttl >= 0)
 
@@ -132,6 +139,7 @@ class DNSTest(unittest.TestCase):
             self.result, self.errorno = result, errorno
         self.channel.query('livechat.ripe.net', pycares.QUERY_TYPE_CNAME, cb)
         self.wait()
+        self.assertEqual(type(self.result), pycares.ares_query_cname_result)
         self.assertEqual(self.errorno, None)
 
     def test_query_mx(self):
@@ -142,6 +150,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(self.errorno, None)
         for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_mx_result)
             self.assertTrue(r.ttl >= 0)
 
     def test_query_ns(self):
@@ -151,6 +160,8 @@ class DNSTest(unittest.TestCase):
         self.channel.query('google.com', pycares.QUERY_TYPE_NS, cb)
         self.wait()
         self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_ns_result)
 
     def test_query_txt(self):
         self.result, self.errorno = None, None
@@ -160,6 +171,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(self.errorno, None)
         for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_txt_result)
             self.assertTrue(r.ttl >= 0)
 
     def test_query_soa(self):
@@ -168,6 +180,7 @@ class DNSTest(unittest.TestCase):
             self.result, self.errorno = result, errorno
         self.channel.query('google.com', pycares.QUERY_TYPE_SOA, cb)
         self.wait()
+        self.assertEqual(type(self.result), pycares.ares_query_soa_result)
         self.assertEqual(self.errorno, None)
         self.assertTrue(self.result.ttl >= 0)
 
@@ -179,6 +192,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(self.errorno, None)
         for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_srv_result)
             self.assertTrue(r.ttl >= 0)
 
     def test_query_naptr(self):
@@ -189,6 +203,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(self.errorno, None)
         for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_naptr_result)
             self.assertTrue(r.ttl >= 0)
 
     def test_query_ptr(self):
@@ -198,6 +213,7 @@ class DNSTest(unittest.TestCase):
         ip = '8.8.8.8'
         self.channel.query(pycares.reverse_address(ip), pycares.QUERY_TYPE_PTR, cb)
         self.wait()
+        self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
 
     def test_query_ptr_ipv6(self):
@@ -207,6 +223,7 @@ class DNSTest(unittest.TestCase):
         ip = '2001:4860:4860::8888'
         self.channel.query(pycares.reverse_address(ip), pycares.QUERY_TYPE_PTR, cb)
         self.wait()
+        self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
 
     def test_query_cancelled(self):
@@ -216,6 +233,7 @@ class DNSTest(unittest.TestCase):
         self.channel.query('google.com', pycares.QUERY_TYPE_NS, cb)
         self.channel.cancel()
         self.wait()
+        self.assertEqual(self.result, None)
         self.assertEqual(self.errorno, pycares.errno.ARES_ECANCELLED)
 
     def test_channel_destroyed(self):
@@ -233,6 +251,7 @@ class DNSTest(unittest.TestCase):
         self.channel.servers = ['1.2.3.4']
         self.channel.query('google.com', pycares.QUERY_TYPE_A, cb)
         self.wait()
+        self.assertEqual(self.result, None)
         self.assertEqual(self.errorno, pycares.errno.ARES_ETIMEOUT)
 
     def test_reverse_address(self):
@@ -254,6 +273,7 @@ class DNSTest(unittest.TestCase):
         self.assertTrue(timeout > 0.0)
         self.channel.cancel()
         self.wait()
+        self.assertEqual(self.result, None)
         self.assertEqual(self.errorno, pycares.errno.ARES_ECANCELLED)
 
 

--- a/tests.py
+++ b/tests.py
@@ -33,149 +33,190 @@ class DNSTest(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyaddr(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         self.channel.gethostbyaddr('127.0.0.1', cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyaddr6(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         self.channel.gethostbyaddr('::1', cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyname(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         self.channel.gethostbyname('localhost', socket.AF_INET, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyname_small_timeout(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         self.channel = pycares.Channel(timeout=0.5, tries=1)
         self.channel.gethostbyname('localhost', socket.AF_INET, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_getnameinfo(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            self.assertEqual(result, ('localhost', 'http'))
+            self.result, self.errorno = result, errorno
         self.channel.getnameinfo(('127.0.0.1', 80), pycares.ARES_NI_LOOKUPHOST|pycares.ARES_NI_LOOKUPSERVICE, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        self.assertIn(self.result[0], ('localhost.localdomain', 'localhost'))
+        self.assertEqual(self.result[1], 'http')
 
     def test_query_a(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            for r in result:
-                self.assertNotEqual(r.host, None)
-                self.assertTrue(r.ttl >= 0)
+            self.result, self.errorno = result, errorno
         self.channel.query('google.com', pycares.QUERY_TYPE_A, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertNotEqual(r.host, None)
+            self.assertTrue(r.ttl >= 0)
 
     def test_query_a_bad(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(result, None)
-            self.assertEqual(errorno, pycares.errno.ARES_ENOTFOUND)
+            self.result, self.errorno = result, errorno
         self.channel.query('hgf8g2od29hdohid.com', pycares.QUERY_TYPE_A, cb)
         self.wait()
+        self.assertEqual(self.result, None)
+        self.assertEqual(self.errorno, pycares.errno.ARES_ENOTFOUND)
 
     def test_query_a_rotate(self):
+        self.result, self.errorno = None, None
+        self.errorno_count, self.count = 0, 0
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
+            if errorno:
+                self.errorno_count += 1
             self.count += 1
-        self.count = 0
         self.channel = pycares.Channel(timeout=1.0, tries=1, rotate=True)
         self.channel.query('google.com', pycares.QUERY_TYPE_A, cb)
         self.channel.query('google.com', pycares.QUERY_TYPE_A, cb)
         self.channel.query('google.com', pycares.QUERY_TYPE_A, cb)
         self.wait()
         self.assertEqual(self.count, 3)
+        self.assertEqual(self.errorno_count, 0)
 
     def test_query_aaaa(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            for r in result:
-                self.assertNotEqual(r.host, None)
-                self.assertTrue(r.ttl >= 0)
+            self.result, self.errorno = result, errorno
         self.channel.query('ipv6.google.com', pycares.QUERY_TYPE_AAAA, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertNotEqual(r.host, None)
+            self.assertTrue(r.ttl >= 0)
 
     def test_query_cname(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         self.channel.query('livechat.ripe.net', pycares.QUERY_TYPE_CNAME, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     def test_query_mx(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            for r in result:
-                self.assertTrue(r.ttl >= 0)
+            self.result, self.errorno = result, errorno
         self.channel.query('google.com', pycares.QUERY_TYPE_MX, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertTrue(r.ttl >= 0)
 
     def test_query_ns(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         self.channel.query('google.com', pycares.QUERY_TYPE_NS, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     def test_query_txt(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            for r in result:
-                self.assertTrue(r.ttl >= 0)
+            self.result, self.errorno = result, errorno
         self.channel.query('google.com', pycares.QUERY_TYPE_TXT, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertTrue(r.ttl >= 0)
 
     def test_query_soa(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            self.assertTrue(result.ttl >= 0)
+            self.result, self.errorno = result, errorno
         self.channel.query('google.com', pycares.QUERY_TYPE_SOA, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        self.assertTrue(self.result.ttl >= 0)
 
     def test_query_srv(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            for r in result:
-                self.assertTrue(r.ttl >= 0)
+            self.result, self.errorno = result, errorno
         self.channel.query('_xmpp-server._tcp.google.com', pycares.QUERY_TYPE_SRV, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertTrue(r.ttl >= 0)
 
     def test_query_naptr(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
-            for r in result:
-                self.assertTrue(r.ttl >= 0)
+            self.result, self.errorno = result, errorno
         self.channel.query('sip2sip.info', pycares.QUERY_TYPE_NAPTR, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertTrue(r.ttl >= 0)
 
     def test_query_ptr(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         ip = '8.8.8.8'
         self.channel.query(pycares.reverse_address(ip), pycares.QUERY_TYPE_PTR, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     def test_query_ptr_ipv6(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, None)
+            self.result, self.errorno = result, errorno
         ip = '2001:4860:4860::8888'
         self.channel.query(pycares.reverse_address(ip), pycares.QUERY_TYPE_PTR, cb)
         self.wait()
+        self.assertEqual(self.errorno, None)
 
     def test_query_cancelled(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, pycares.errno.ARES_ECANCELLED)
+            self.result, self.errorno = result, errorno
         self.channel.query('google.com', pycares.QUERY_TYPE_NS, cb)
         self.channel.cancel()
         self.wait()
+        self.assertEqual(self.errorno, pycares.errno.ARES_ECANCELLED)
 
     def test_channel_destroyed(self):
         self.channel.destroy()
@@ -186,11 +227,13 @@ class DNSTest(unittest.TestCase):
         self.wait()
 
     def test_query_timeout(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, pycares.errno.ARES_ETIMEOUT)
+            self.result, self.errorno = result, errorno
         self.channel.servers = ['1.2.3.4']
         self.channel.query('google.com', pycares.QUERY_TYPE_A, cb)
         self.wait()
+        self.assertEqual(self.errorno, pycares.errno.ARES_ETIMEOUT)
 
     def test_reverse_address(self):
         s = '1.2.3.4'
@@ -198,14 +241,16 @@ class DNSTest(unittest.TestCase):
         self.assertEqual(pycares.reverse_address(s), expected)
 
     def test_channel_timeout(self):
+        self.result, self.errorno = None, None
         def cb(result, errorno):
-            self.assertEqual(errorno, pycares.errno.ARES_ECANCELLED)
+            self.result, self.errorno = result, errorno
         self.channel = pycares.Channel(timeout=0.5, tries=1)
         self.channel.gethostbyname('google.com', socket.AF_INET, cb)
         timeout = self.channel.timeout()
         self.assertTrue(timeout > 0.0)
         self.channel.cancel()
         self.wait()
+        self.assertEqual(self.errorno, pycares.errno.ARES_ECANCELLED)
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -240,6 +240,10 @@ class DNSTest(unittest.TestCase):
         expected = '4.3.2.1.in-addr.arpa'
         self.assertEqual(pycares.reverse_address(s), expected)
 
+        s = '2607:f8b0:4010:801::1013'
+        expected = '3.1.0.1.0.0.0.0.0.0.0.0.0.0.0.0.1.0.8.0.0.1.0.4.0.b.8.f.7.0.6.2.ip6.arpa'
+        self.assertEqual(pycares.reverse_address(s), expected)
+
     def test_channel_timeout(self):
         self.result, self.errorno = None, None
         def cb(result, errorno):


### PR DESCRIPTION
This corrects multiple production reliability and clean coding issues found doing some large scale DNS resolution:

1. `setup.py` not marked executable and missing shebang.
2. UTs performed assertions in callback, but C code discards any exceptions from callback; moved them out of callback to regular Python context so broken UTs will actually fail.
3. UT for `reverse_address` did not test with IPv6, only IPv4.
4. Query result struct-sequence types were not registered to any namespace; thus it was impossible to write generic DNS processing code using `isinstance(result, pycares.ares_query_simple_result)` and so forth, because `pycares.ares_query_simple_result` did not exist, so you could not compare against the unregistered raw type `ares_query_simple_result` that was only visible from C and not Python.
5. UT assertion for correct return type of `None` in error case and `ares_X_result` added to all UT functions.
6. C extension modified to call `PyCaresModule_AddType` to register result struct-sequence types.