### PR TITLE
Correct (?) documentation to reflect new build process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Linux:
 
 ::
 
-    ./build_inplace
+    python setup.py install
 
 Mac OSX:
 
@@ -47,7 +47,7 @@ Mac OSX:
 
     (XCode needs to be installed)
     export ARCHFLAGS="-arch x86_64"
-    ./build_inplace
+    python setup.py install
 
 Microsoft Windows (with Visual Studio 2008, 2010, 2015 or the Windows SDK):
 


### PR DESCRIPTION
`build_inplace` doesn't work for me any more on Linux or OS X, but simply running `python setup.py install` (with or without a venv) seems to do the trick.  Unsure about Windows due to lack of test environment.  If it can also use the same command, `build_inplace` should be removed.