### PR TITLE
PTR Enhance

### DIFF
--- a/deps/c-ares/src/ares.h
+++ b/deps/c-ares/src/ares.h
@@ -602,7 +602,8 @@ CARES_EXTERN int ares_parse_ptr_reply(const unsigned char *abuf,
                                       const void *addr,
                                       int addrlen,
                                       int family,
-                                      struct hostent **host);
+                                      struct hostent **host,
+                                      int *hostttl);
 
 CARES_EXTERN int ares_parse_ns_reply(const unsigned char *abuf,
                                      int alen,

--- a/deps/c-ares/src/ares_gethostbyaddr.c
+++ b/deps/c-ares/src/ares_gethostbyaddr.c
@@ -147,13 +147,13 @@ static void addr_callback(void *arg, int status, int timeouts,
         {
           addrlen = sizeof(aquery->addr.addrV4);
           status = ares_parse_ptr_reply(abuf, alen, &aquery->addr.addrV4,
-                                        (int)addrlen, AF_INET, &host);
+                                        (int)addrlen, AF_INET, &host, NULL);
         }
       else
         {
           addrlen = sizeof(aquery->addr.addrV6);
           status = ares_parse_ptr_reply(abuf, alen, &aquery->addr.addrV6,
-                                        (int)addrlen, AF_INET6, &host);
+                                        (int)addrlen, AF_INET6, &host, NULL);
         }
       end_aquery(aquery, status, host);
     }

--- a/deps/c-ares/src/ares_parse_ptr_reply.c
+++ b/deps/c-ares/src/ares_parse_ptr_reply.c
@@ -35,16 +35,21 @@
 #  include <strings.h>
 #endif
 
+#ifdef HAVE_LIMITS_H
+#  include <limits.h>
+#endif
+
 #include "ares.h"
 #include "ares_dns.h"
 #include "ares_nowarn.h"
 #include "ares_private.h"
 
 int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
-                         int addrlen, int family, struct hostent **host)
+                         int addrlen, int family, struct hostent **host,
+                         int *hostttl)
 {
   unsigned int qdcount, ancount;
-  int status, i, rr_type, rr_class, rr_len;
+  int status, i, rr_type, rr_class, rr_len, rr_ttl;
   long len;
   const unsigned char *aptr;
   char *ptrname, *hostname, *rr_name, *rr_data;
@@ -55,6 +60,8 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
 
   /* Set *host to NULL for all failure cases. */
   *host = NULL;
+  if (hostttl)
+      *hostttl = INT_MAX;
 
   /* Give up if abuf doesn't have room for a header. */
   if (alen < HFIXEDSZ)
@@ -102,6 +109,7 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
       rr_type = DNS_RR_TYPE(aptr);
       rr_class = DNS_RR_CLASS(aptr);
       rr_len = DNS_RR_LEN(aptr);
+      rr_ttl = DNS_RR_TTL(aptr);
       aptr += RRFIXEDSZ;
       if (aptr + rr_len > abuf + alen)
         {
@@ -143,6 +151,13 @@ int ares_parse_ptr_reply(const unsigned char *abuf, int alen, const void *addr,
               break;
             }
             aliases = ptr;
+          }
+          if (hostttl)
+          {
+            if (*hostttl > rr_ttl)
+            {
+              *hostttl = rr_ttl;
+            }
           }
         }
 

--- a/pycares/_cfficore/__init__.py
+++ b/pycares/_cfficore/__init__.py
@@ -240,12 +240,13 @@ def _query_cb(arg, status, timeouts, abuf, alen):
 
         elif query_type == _lib.T_PTR:
             hostent = _ffi.new("struct hostent **")
-            parse_status = _lib.ares_parse_ptr_reply(abuf, alen, _ffi.NULL, 0, socket.AF_UNSPEC, hostent);
+            hostttl = _ffi.new("int*", PYCARES_ADDRTTL_SIZE)
+            parse_status = _lib.ares_parse_ptr_reply(abuf, alen, _ffi.NULL, 0, socket.AF_UNSPEC, hostent, hostttl);
             if parse_status != ARES_SUCCESS:
                 result = None
                 status = parse_status
             else:
-                result = ares_query_ptr_result(hostent[0])
+                result = ares_query_ptr_result(hostent[0], hostttl[0])
                 _lib.ares_free_hostent(hostent[0])
                 status = None
 
@@ -631,9 +632,9 @@ class ares_query_ns_result(object):
 
 
 class ares_query_ptr_result(object):
-    def __init__(self, hostent):
+    def __init__(self, hostent, ttl):
         self.name = _ffi_string(hostent.h_name)
-        self.ttl = None
+        self.ttl = ttl
 
 
 class ares_query_soa_result(object):

--- a/pycares/_cfficore/__init__.py
+++ b/pycares/_cfficore/__init__.py
@@ -246,7 +246,13 @@ def _query_cb(arg, status, timeouts, abuf, alen):
                 result = None
                 status = parse_status
             else:
-                result = ares_query_ptr_result(hostent[0], hostttl[0])
+                aliases = []
+                i = 0
+                terminator = _ffi.cast('char*', _ffi.NULL)
+                while hostent[0].h_aliases[i] != terminator:
+                    aliases.append(_ffi.string(hostent[0].h_aliases[i]))
+                    i += 1
+                result = ares_query_ptr_result(hostent[0], hostttl[0], aliases)
                 _lib.ares_free_hostent(hostent[0])
                 status = None
 
@@ -632,9 +638,10 @@ class ares_query_ns_result(object):
 
 
 class ares_query_ptr_result(object):
-    def __init__(self, hostent, ttl):
+    def __init__(self, hostent, ttl, aliases):
         self.name = _ffi_string(hostent.h_name)
         self.ttl = ttl
+        self.aliases = aliases
 
 
 class ares_query_soa_result(object):

--- a/pycares/_cfficore/pycares_build.py
+++ b/pycares/_cfficore/pycares_build.py
@@ -579,7 +579,8 @@ int ares_parse_ptr_reply(const unsigned char *abuf,
                                       const void *addr,
                                       int addrlen,
                                       int family,
-                                      struct hostent **host);
+                                      struct hostent **host,
+                                      int *hostttl);
 
 int ares_parse_ns_reply(const unsigned char *abuf,
                                      int alen,

--- a/src/cares.c
+++ b/src/cares.c
@@ -396,7 +396,8 @@ query_ptr_cb(void *arg, int status,int timeouts, unsigned char *answer_buf, int 
     PyGILState_STATE gstate = PyGILState_Ensure();
     int parse_status;
     struct hostent *hostent = NULL;
-    PyObject *dns_result, *errorno, *result, *callback;
+    PyObject *dns_result, *errorno, *result, *callback, *aliases;
+    char **alias;
 
     int hostttls;
 
@@ -429,8 +430,14 @@ query_ptr_cb(void *arg, int status,int timeouts, unsigned char *answer_buf, int 
         goto callback;
     }
 
+    aliases = PyList_New(0);
+    for(alias = hostent->h_aliases; *alias != NULL; ++alias)
+    {
+        PyList_Append(aliases, Py_BuildValue("s", *alias));
+    }
     PyStructSequence_SET_ITEM(dns_result, 0, Py_BuildValue("s", hostent->h_name));
     PyStructSequence_SET_ITEM(dns_result, 1, Py_BuildValue("d", hostttls));
+    PyStructSequence_SET_ITEM(dns_result, 2, aliases);
     Py_INCREF(Py_None);
     errorno = Py_None;
     Py_INCREF(Py_None);

--- a/src/cares.c
+++ b/src/cares.c
@@ -398,6 +398,8 @@ query_ptr_cb(void *arg, int status,int timeouts, unsigned char *answer_buf, int 
     struct hostent *hostent = NULL;
     PyObject *dns_result, *errorno, *result, *callback;
 
+    int hostttls;
+
     callback = (PyObject *)arg;
     ASSERT(callback);
 
@@ -409,7 +411,7 @@ query_ptr_cb(void *arg, int status,int timeouts, unsigned char *answer_buf, int 
     }
 
     /* addr is only used to populate the hostent struct, it's not used to validate the response */
-    parse_status = ares_parse_ptr_reply(answer_buf, answer_len, NULL, 0, AF_UNSPEC, &hostent);
+    parse_status = ares_parse_ptr_reply(answer_buf, answer_len, NULL, 0, AF_UNSPEC, &hostent, &hostttls);
     if (parse_status != ARES_SUCCESS) {
         errorno = PyInt_FromLong((long)parse_status);
         dns_result = Py_None;
@@ -428,8 +430,7 @@ query_ptr_cb(void *arg, int status,int timeouts, unsigned char *answer_buf, int 
     }
 
     PyStructSequence_SET_ITEM(dns_result, 0, Py_BuildValue("s", hostent->h_name));
-    /* TODO: add (real) TTL */
-    PyStructSequence_SET_ITEM(dns_result, 1, Py_None);
+    PyStructSequence_SET_ITEM(dns_result, 1, Py_BuildValue("d", hostttls));
     Py_INCREF(Py_None);
     errorno = Py_None;
     Py_INCREF(Py_None);

--- a/src/pycares.h
+++ b/src/pycares.h
@@ -175,6 +175,7 @@ static PyTypeObject AresQueryPTRResultType;
 static PyStructSequence_Field ares_query_ptr_result_fields[] = {
     {"name", ""},
     {"ttl", ""},
+    {"aliases", ""},
     {NULL}
 };
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -239,6 +239,7 @@ class DNSTest(unittest.TestCase):
         self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
         self.assertGreater(self.result.ttl, 0)
+        self.assertEqual(type(self.result.aliases), list)
 
     def test_query_ptr_ipv6(self):
         self.result, self.errorno = None, None
@@ -250,6 +251,8 @@ class DNSTest(unittest.TestCase):
         self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
         self.assertGreater(self.result.ttl, 0)
+        self.assertEqual(type(self.result.aliases), list)
+
 
     def test_query_cancelled(self):
         self.result, self.errorno = None, None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -238,6 +238,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
+        self.assertGreater(self.result.ttl, 0)
 
     def test_query_ptr_ipv6(self):
         self.result, self.errorno = None, None
@@ -248,6 +249,7 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
+        self.assertGreater(self.result.ttl, 0)
 
     def test_query_cancelled(self):
         self.result, self.errorno = None, None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -137,7 +137,7 @@ class DNSTest(unittest.TestCase):
         self.result, self.errorno = None, None
         def cb(result, errorno):
             self.result, self.errorno = result, errorno
-        self.channel.query('livechat.ripe.net', pycares.QUERY_TYPE_CNAME, cb)
+        self.channel.query('www.amazon.com', pycares.QUERY_TYPE_CNAME, cb)
         self.wait()
         self.assertEqual(type(self.result), pycares.ares_query_cname_result)
         self.assertEqual(self.errorno, None)


### PR DESCRIPTION
PTR requests TTL and Aliases parsing.

I don't know any way to automate the aliases parsing as it's not recommended to have more than one PTR record, but it can happen. I tested it on a local BIND setup.