### PR TITLE
core: CPython implementation TTL parsing issue

### DIFF
--- a/src/cares.c
+++ b/src/cares.c
@@ -436,7 +436,7 @@ query_ptr_cb(void *arg, int status,int timeouts, unsigned char *answer_buf, int 
         PyList_Append(aliases, Py_BuildValue("s", *alias));
     }
     PyStructSequence_SET_ITEM(dns_result, 0, Py_BuildValue("s", hostent->h_name));
-    PyStructSequence_SET_ITEM(dns_result, 1, Py_BuildValue("d", hostttls));
+    PyStructSequence_SET_ITEM(dns_result, 1, Py_BuildValue("i", hostttls));
     PyStructSequence_SET_ITEM(dns_result, 2, aliases);
     Py_INCREF(Py_None);
     errorno = Py_None;

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -238,7 +238,9 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
-        self.assertGreater(self.result.ttl, 0)
+        self.assertIsInstance(self.result.ttl, int)
+        self.assertGreaterEqual(self.result.ttl, 0)
+        self.assertLessEqual(self.result.ttl, 2**31-1)
         self.assertEqual(type(self.result.aliases), list)
 
     def test_query_ptr_ipv6(self):
@@ -250,7 +252,9 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertEqual(type(self.result), pycares.ares_query_ptr_result)
         self.assertEqual(self.errorno, None)
-        self.assertGreater(self.result.ttl, 0)
+        self.assertIsInstance(self.result.ttl, int)
+        self.assertGreaterEqual(self.result.ttl, 0)
+        self.assertLessEqual(self.result.ttl, 2**31-1)
         self.assertEqual(type(self.result.aliases), list)
 
 


### PR DESCRIPTION
CPython implementation was interpreting the TTL data as a float, returning invalid data.
CFFI implementation had no problems.

Also improved unit test to verify the types and constraints of the TTL data type