### PR TITLE
core: fix parsing TXT records with invalid UTF-8 chars

### DIFF
--- a/pycares/_cfficore/__init__.py
+++ b/pycares/_cfficore/__init__.py
@@ -674,7 +674,7 @@ class  ares_query_srv_result(object):
 
 class ares_query_txt_result(object):
     def __init__(self, txt):
-        self.text = _ffi_string(txt.txt)
+        self.text = _ffi.string(txt.txt)
         self.ttl = txt.ttl
 
 

--- a/src/cares.c
+++ b/src/cares.c
@@ -503,10 +503,9 @@ query_txt_cb(void *arg, int status,int timeouts, unsigned char *answer_buf, int 
         if (txt_ptr == NULL || txt_ptr->record_start == 1) {
             if (tmp_obj != NULL) {
                 /* Add the assembled record to the result when seeing a new record (except for the first time) and after the last chunk has been seen */
-                PyStructSequence_SET_ITEM(tmp_obj, 0, Py_BuildValue("s", PyBytes_AS_STRING(assembled_txt)));
+                PyStructSequence_SET_ITEM(tmp_obj, 0, assembled_txt);
                 PyList_Append(dns_result, tmp_obj);
                 Py_DECREF(tmp_obj);
-                Py_DECREF(assembled_txt);
             }
             if (txt_ptr == NULL) {
                 /* Exit while loop when last chunk has been seen */

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -184,7 +184,7 @@ class DNSTest(unittest.TestCase):
         # If the chunks are aggregated, only one TXT record should be visible. Three would show if they are not properly merged.
         # jobscoutdaily.com.    21600   IN  TXT "v=spf1 " "include:emailcampaigns.net include:spf.dynect.net  include:ccsend.com include:_spf.elasticemail.com ip4:67.200.116.86 ip4:67.200.116.90 ip4:67.200.116.97 ip4:67.200.116.111 ip4:74.199.198.2 " " ~all"
         self.assertEqual(len(self.result), 1)
-        self.assertEqual(self.result[0].text, "v=spf1 include:emailcampaigns.net include:spf.dynect.net  include:ccsend.com include:_spf.elasticemail.com ip4:67.200.116.86 ip4:67.200.116.90 ip4:67.200.116.97 ip4:67.200.116.111 ip4:74.199.198.2  ~all")
+        self.assertEqual(self.result[0].text, b'v=spf1 include:emailcampaigns.net include:spf.dynect.net  include:ccsend.com include:_spf.elasticemail.com ip4:67.200.116.86 ip4:67.200.116.90 ip4:67.200.116.97 ip4:67.200.116.111 ip4:74.199.198.2  ~all')
 
     def test_query_txt_multiple_chunked(self):
         self.result, self.errorno = None, None
@@ -196,6 +196,30 @@ class DNSTest(unittest.TestCase):
         # s-pulse.co.jp.      3600    IN  TXT "MS=ms18955624"
         # s-pulse.co.jp.      3600    IN  TXT "v=spf1 " "include:spf-bma.mpme.jp ip4:202.248.11.9 ip4:202.248.11.10 " "ip4:218.223.68.132 ip4:218.223.68.77 ip4:210.254.139.121 " "ip4:211.128.73.121 ip4:210.254.139.122 ip4:211.128.73.122 " "ip4:210.254.139.123 ip4:211.128.73.123 ip4:210.254.139.124 " "ip4:211.128.73.124 ip4:210.254.139.13 ip4:211.128.73.13 " "ip4:52.68.199.198 include:spf.betrend.com " "include:spf.protection.outlook.com " "~all"
         self.assertEqual(len(self.result), 2)
+
+    def test_query_txt_bytes1(self):
+        self.result, self.errorno = None, None
+        def cb(result, errorno):
+            self.result, self.errorno = result, errorno
+        self.channel.query('like.com.sa', pycares.QUERY_TYPE_TXT, cb)
+        self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_txt_result)
+            self.assertIsInstance(r.text, bytes)
+            self.assertTrue(r.ttl >= 0)
+
+    def test_query_txt_bytes2(self):
+        self.result, self.errorno = None, None
+        def cb(result, errorno):
+            self.result, self.errorno = result, errorno
+        self.channel.query('wide.com.es', pycares.QUERY_TYPE_TXT, cb)
+        self.wait()
+        self.assertEqual(self.errorno, None)
+        for r in self.result:
+            self.assertEqual(type(r), pycares.ares_query_txt_result)
+            self.assertIsInstance(r.text, bytes)
+            self.assertTrue(r.ttl >= 0)
 
     def test_query_soa(self):
         self.result, self.errorno = None, None


### PR DESCRIPTION
Return a the assembled bytes object instead. This also saves a bytes ->
string conversion, which is a good thing.

Fixes: https://github.com/saghul/aiodns/issues/32