### PR TITLE
build: fix MinGW build

### DIFF
--- a/deps/c-ares/src/ares.h
+++ b/deps/c-ares/src/ares.h
@@ -129,7 +129,7 @@ extern "C" {
 
 #ifdef CARES_STATICLIB
 #  define CARES_EXTERN
-#elif defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__)
+#elif (defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__)) && !defined(__GNUC__)
 #  if defined(CARES_BUILDING_LIBRARY)
 #    define CARES_EXTERN  __declspec(dllexport)
 #  else

--- a/setup_cares.py
+++ b/setup_cares.py
@@ -90,7 +90,8 @@ class cares_build_ext(build_ext):
             self.compiler.add_library('lkstat')
         elif sys.platform == 'win32':
             self.compiler.add_include_dir(os.path.join(self.cares_dir, 'src/config_win32'))
-            self.extensions[0].extra_link_args = ['/NODEFAULTLIB:libcmt']
+            if "mingw" not in self.compiler.compiler_type:
+                self.extensions[0].extra_link_args = ['/NODEFAULTLIB:libcmt']
             self.compiler.add_library('advapi32')
             self.compiler.add_library('iphlpapi')
             self.compiler.add_library('psapi')


### PR DESCRIPTION
MSYS2 sets up MinGW environment where GCC is used, which is not happy when being fed with VC-style options (/NODEFAULTLIB) and dllimport/dllexport crap