### PR TITLE
Add FreeBSD building instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,12 @@ Linux:
 
     python setup.py install
 
+FreeBSD:
+
+::
+
+    cd /usr/ports/dns/py-pycares && make install
+
 Mac OSX:
 
 ::


### PR DESCRIPTION
It is recommended to use the pycares port for that.