### PR TITLE
fix path of _version.py file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 import re
 
 def get_version():
-    return re.search(r"""__version__\s+=\s+(?P<quote>['"])(?P<version>.+?)(?P=quote)""", open('../pycares/_version.py').read()).group('version')
+    return re.search(r"""__version__\s+=\s+(?P<quote>['"])(?P<version>.+?)(?P=quote)""", open('../src/pycares/_version.py').read()).group('version')
 _version = get_version()
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
The relative path of _version.py when starting from the docs/ subdirectory is wrong. This fix the '$ make html' build from the docs/ subdirectory.