### PR TITLE
let "pycares" support  ARES_OPT_LOOKUPS option.

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -360,7 +360,7 @@ class Channel:
             optmask = optmask |  _lib.ARES_OPT_SOCK_STATE_CB
 
         if lookups:
-            options.lookups = lookups
+            options.lookups = _ffi.new('char[]', ascii_bytes(lookups))
             optmask = optmask |  _lib.ARES_OPT_LOOKUPS
 
         if domains:


### PR DESCRIPTION
 Reproduce:
#############
import pycares
from tornado.tcpclient import Resolver                
Resolver.configure('tornado.platform.caresresolver.CaresResolver')                                                                        
resolver = Resolver()
resolver.channel = pycares.Channel(sock_state_cb=resolver._sock_state_cb, timeout=1, tries=1,
    socket_receive_buffer_size=4096, servers=['127.0.0.1'], tcp_port=5353, udp_port=5353, rotate=False)


##################
Error:    TypeError: initializer for ctype 'char *' must be a cdata pointer, not str