### PR TITLE
Update ares_query_txt_result_chunk to return bytes rather than str

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -760,7 +760,7 @@ class ares_query_txt_result_chunk(AresResult):
     type = 'TXT'
 
     def __init__(self, txt):
-        self.text = _ffi.string(txt.txt)
+        self.text = bytes(_ffi.buffer(txt.txt, txt.length))
         self.ttl = -1
 
 


### PR DESCRIPTION
The RFC1035 specification says that TXT records are allowed to contain <character-string> data made of arbitrary binary data, but right now aiodns is parsing it as a str, and therefore will stop on a null byte, this PR fixes this