### PR TITLE
Use stable 3.10, rather than dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10-dev']
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Now that the stable version of 3.10 has been released, we can use that.

This will also include creating a GitHub release, so that the CI actually runs, build wheels and pushes to PyPi