### PR TITLE
core: add flexible member to ares_addrinfo to fix c-ares 1.18

### DIFF
--- a/src/_cffi_src/build_cares.py
+++ b/src/_cffi_src/build_cares.py
@@ -337,6 +337,7 @@ struct ares_addrinfo_cname {
 struct ares_addrinfo {
   struct ares_addrinfo_cname *cnames;
   struct ares_addrinfo_node  *nodes;
+  ...;
 };
 
 struct ares_addrinfo_hints {


### PR DESCRIPTION
Add a flexible member to account for c-ares 1.18 adding an additional
`name` member to `struct ares_addrinfo`.  This fixes the following
exception from cffi, and the resulting test_getaddrinfo* failures:

```pytb
Exception ignored from cffi callback <function _addrinfo_cb at 0x7f5fa890d040>:
Traceback (most recent call last):
  File "/tmp/pycares/.tox/py39/lib/python3.9/site-packages/pycares/__init__.py", line 162, in _addrinfo_cb
    result = ares_addrinfo_result(res)
  File "/tmp/pycares/.tox/py39/lib/python3.9/site-packages/pycares/__init__.py", line 841, in __init__
    cname_ptr = ares_addrinfo.cnames
ffi.error: struct ares_addrinfo: wrong total size (cdef says 16, but C compiler says 24). fix it or use "...;" as the last field in the cdef for struct ares_addrinfo to make it flexible
```