### PR TITLE
Build macOS arm64 and musllinux wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v2
@@ -20,11 +20,12 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.0.1
+        uses: pypa/cibuildwheel@v2.8.1
         with:
           output-dir: ./wheelhouse
         env:
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
           CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BEFORE_ALL_LINUX: yum install -y libffi-devel

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -28,4 +28,5 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_PRERELEASE_PYTHONS: True
-          CIBW_BEFORE_ALL_LINUX: yum install -y libffi-devel
+          CIBW_BEFORE_ALL_LINUX: |-
+            command -v yum && yum install -y libffi-devel || apk add libffi-dev

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -7,6 +7,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-11]
 
@@ -23,3 +24,5 @@ jobs:
         uses: pypa/cibuildwheel@v2.8.1
         with:
           output-dir: ./wheelhouse
+        env:
+          CIBW_PRERELEASE_PYTHONS: True

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,10 +23,3 @@ jobs:
         uses: pypa/cibuildwheel@v2.8.1
         with:
           output-dir: ./wheelhouse
-        env:
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
-          CIBW_ARCHS_LINUX: auto aarch64
-          CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_BEFORE_ALL_LINUX: |-
-            command -v yum && yum install -y libffi-devel || apk add libffi-dev

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v2
@@ -23,12 +23,13 @@ jobs:
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.0.1
+        uses: pypa/cibuildwheel@v2.8.1
         with:
           output-dir: ./wheelhouse
         env:
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
           CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BEFORE_ALL_LINUX: yum install -y libffi-devel
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -31,7 +31,8 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_PRERELEASE_PYTHONS: True
-          CIBW_BEFORE_ALL_LINUX: yum install -y libffi-devel
+          CIBW_BEFORE_ALL_LINUX: |-
+            command -v yum && yum install -y libffi-devel || apk add libffi-dev
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -26,13 +26,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.8.1
         with:
           output-dir: ./wheelhouse
-        env:
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
-          CIBW_ARCHS_LINUX: auto aarch64
-          CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_BEFORE_ALL_LINUX: |-
-            command -v yum && yum install -y libffi-devel || apk add libffi-dev
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Install dependencies
       run: python -m pip install -U setuptools wheel
     - name: Build package
-      run: python setup.py install
+      run: python -m pip install .
     - name: Run tests
       run: python tests/tests.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,27 @@
 [build-system]
 requires = ["setuptools", "wheel", "cffi>=1.5.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build = "cp36-* cp37-* cp38-* cp39-* cp310-*"
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]
+before-all = """
+set -eux
+# musllinux_*
+if command -v apk; then
+    apk add libffi-dev
+fi
+# manylinux_2_24
+if command -v apt; then
+    apt install libffi-dev
+fi
+# manylinux_*
+if command -v yum; then
+    yum install -y libffi-devel
+fi
+"""
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "universal2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "cffi>=1.5.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = "cp36-* cp37-* cp38-* cp39-* cp310-*"
+build = "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*"
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cffi>=1.5.0"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "cffi>=1.5.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*"
+build = "cp3*"
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import codecs
+import os
 import re
+import sys
+
+# we have to import setup_cares.py which is in project's root folder
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
 from setuptools import setup
 
@@ -40,7 +45,6 @@ setup(name             = 'pycares',
           'Programming Language :: Python :: Implementation :: PyPy',
       ],
       cmdclass         = {'build_ext': cares_build_ext},
-      setup_requires   = ['cffi>=1.5.0'],
       install_requires = ['cffi>=1.5.0'],
       extras_require   = {'idna': ['idna >= 2.1']},
       cffi_modules     = ['src/_cffi_src/build_cares.py:ffi'],


### PR DESCRIPTION
This PR enables building of musllinux wheels *and* macOS universal2 wheels which support both x86_64 and the new arm64 platforms

While trying to build the wheels, I've ran into an issue with the legacy setuptools backend so I updated this project to use PEP 517 compatible build system (a matter of adding `pyproject.toml` with `setuptools` specified and some minor changes related to the build isolation).

Additionally I made some changes that were not strictly necessary:
- updated macOS version from 10.15 to 11 as the former is deprecated on GH Actions (https://github.com/actions/virtual-environments/issues/5583)
- updated cibuildwheel version because it seemed like a good idea to bump that though I have not run into any bugs with cibuildwheel 2.0.1
- migrated cibuildwheel configuration from Actions workflows to pyproject.toml to de-duplicate it
- removed `CIBW_PRERELEASE_PYTHONS` flag from `release-wheels.yml` workflow to avoid publishing wheels for Python versions that have not reached stable ABI yet
- simplified the list in `CIBW_BUILD` from `cp36-* cp37-* cp38-* cp39-* cp310-*` to `cp3*`
    - if there's ever a need to skip any builds, `CIBW_SKIP` option can easily be used so this is IMO a better way of doing it
    - cibuilwheel is still being pinned so this can't actually cause it to start failing out of nowhere without you explicitly bumping the version

If you think I should split any part of the PR into a separate one, let me know.