### PR TITLE
Bump cibuildwheel to build for Python 3.11 + CI total time speedups

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,25 +4,6 @@ on: [pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
-        with:
-          output-dir: ./wheelhouse
-        env:
-          CIBW_PRERELEASE_PYTHONS: True
+    uses: ./.github/workflows/run-cibuildwheel.yml
+    with:
+      prerelease-pythons: true

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -7,28 +7,9 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
-        with:
-          output-dir: ./wheelhouse
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
+    uses: ./.github/workflows/run-cibuildwheel.yml
+    with:
+      fail-fast: true
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/run-cibuildwheel.yml
+++ b/.github/workflows/run-cibuildwheel.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "CIBW_ARCHS=${{ matrix.cibw_archs }}" >> $GITHUB_ENV
         shell: bash
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.9.0
         with:
           output-dir: ./wheelhouse
         env:

--- a/.github/workflows/run-cibuildwheel.yml
+++ b/.github/workflows/run-cibuildwheel.yml
@@ -1,0 +1,65 @@
+on:
+  workflow_call:
+    inputs:
+      fail-fast:
+        description: Whether the wheel build should stop and fail as soon as any job fails.
+        required: false
+        default: false
+        type: boolean
+      prerelease-pythons:
+        description: Whether the wheels should be built for pre-release Pythons that are not ABI stable yet.
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build_wheels:
+    name: Build wheels for ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: ${{ inputs.fail-fast }}
+      matrix:
+        include:
+          - name: Windows AMD64 & x86
+            os: windows-2019
+          - name: macOS x86_64 & universal2
+            os: macos-11
+          - name: manylinux and musllinux x86_64 & i686
+            os: ubuntu-20.04
+            cibw_build: cp3*-{manylinux,musllinux}_*
+            cibw_archs: auto
+          - name: manylinux aarch64
+            os: ubuntu-20.04
+            cibw_build: cp3*-manylinux_*
+            cibw_archs: aarch64
+          - name: musllinux aarch64
+            os: ubuntu-20.04
+            cibw_build: cp3*-musllinux_*
+            cibw_archs: aarch64
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up QEMU
+        if: runner.os == 'Linux' && matrix.cibw_archs == 'aarch64'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set CIBW_BUILD
+        if: ${{ matrix.cibw_build }}
+        run: echo "CIBW_BUILD=${{ matrix.cibw_build }}" >> $GITHUB_ENV
+        shell: bash
+      - name: Set CIBW_ARCHS
+        if: ${{ matrix.cibw_archs }}
+        run: echo "CIBW_ARCHS=${{ matrix.cibw_archs }}" >> $GITHUB_ENV
+        shell: bash
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.8.1
+        with:
+          output-dir: ./wheelhouse
+        env:
+          CIBW_PRERELEASE_PYTHONS: ${{ inputs.prerelease-pythons }}
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
This PR does 3 things:
- splits out the cibuildwheel run workflow into a separate workflow file that can be called from other workflows (deduplicates the pretty much identical setups in build-wheels.yml and release-wheels.yml)
- cuts the total time of the CI build in half by splitting the Linux run into concurrent jobs:
    - manylinux and musllinux x86_64 & i686 (~11 minutes)
    - manylinux aarch64 (~26 minutes)
    - musllinux aarch64 (~26 minutes)
- bumps cibuildwheel version from 2.8.1 to 2.9.0 to enable Python 3.11 builds with Python 3.11.0rc1 which is guaranteed to be ABI compatible with the final release

I wasn't entirely sure if you'll want the cibuildwheel bump done in this PR along with the changes to how the work is distributed but it's a single line change so it seemed like a reasonable idea. I can split it out into separate PR if you want me to.