### PR TITLE
Bump GitHub Actions versions and fix warnings in the process

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -15,16 +15,16 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
       - name: Build sdist
         run: python setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -34,12 +34,12 @@ jobs:
     # upload to PyPI when a GitHub Release is created
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/run-cibuildwheel.yml
+++ b/.github/workflows/run-cibuildwheel.yml
@@ -38,12 +38,12 @@ jobs:
             cibw_archs: aarch64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.cibw_archs == 'aarch64'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
       - name: Set CIBW_BUILD
@@ -57,11 +57,11 @@ jobs:
       - name: Set CIBW_SKIP
         run: echo "CIBW_SKIP=cp36-*" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.11.3
         with:
           output-dir: ./wheelhouse
         env:
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.prerelease-pythons }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
There are a bunch of warnings related to the use of deprecated node12 runtime and set-output directive in older actions versions, as well as a deprecation warning related to the use of the master branch of the `pypa/gh-action-pypi-publish` action.

Additionally, I bumped up the `cibuildwheel` version which wasn't required but figured I might as well do it here too.