### PR TITLE
Test data updates to fix test failures

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -288,9 +288,9 @@ class DNSTest(unittest.TestCase):
         self.wait()
         self.assertNoError(self.errorno)
         # If the chunks are aggregated, only one TXT record should be visible. Three would show if they are not properly merged.
-        # jobscoutdaily.com.    21600   IN  TXT "v=spf1 " "include:emailcampaigns.net include:spf.dynect.net  include:ccsend.com include:_spf.elasticemail.com ip4:67.200.116.86 ip4:67.200.116.90 ip4:67.200.116.97 ip4:67.200.116.111 ip4:74.199.198.2 " " ~all"
+        # jobscoutdaily.com.    21600   IN  TXT "v=spf1 A MX " "include:emailcampaigns.net include:spf.dynect.net include:ccsend.com include:_spf.elasticemail.com ip4:67.200.116.0/24 ip4:74.199.198.0/24 " " ~all"
         self.assertEqual(len(self.result), 1)
-        self.assertEqual(self.result[0].text, 'v=spf1 include:emailcampaigns.net include:spf.dynect.net  include:ccsend.com include:_spf.elasticemail.com ip4:67.200.116.86 ip4:67.200.116.90 ip4:67.200.116.97 ip4:67.200.116.111 ip4:74.199.198.2  ~all')
+        self.assertEqual(self.result[0].text, 'v=spf1 A MX include:emailcampaigns.net include:spf.dynect.net include:ccsend.com include:_spf.elasticemail.com ip4:67.200.116.0/24 ip4:74.199.198.0/24  ~all')
 
     def test_query_txt_multiple_chunked(self):
         self.result, self.errorno = None, None

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -409,7 +409,7 @@ class DNSTest(unittest.TestCase):
         self.result, self.errorno = None, None
         def cb(result, errorno):
             self.result, self.errorno = result, errorno
-        ip = '8.8.8.8'
+        ip = '172.253.122.26'
         self.channel.query(ipaddress.ip_address(ip).reverse_pointer, pycares.QUERY_TYPE_PTR, cb)
         self.wait()
         self.assertNoError(self.errorno)


### PR DESCRIPTION
Currently we have multiple test failures with pycares 4.4.0 with c-ares 1.24.  Two of the three are unrelated to the new c-ares version:

For test_query_txt_chunked, the jobscoutdaily.com SPF record changed, so the expected result is wrong.  I think it still has the relevant attributes for the test case.

For test_query_ptr, there's no longer a PTR record at 8.8.8.8, so the test failed with pycares (correctly) reported an error.  It looks like any address with a PTR record will meet the requirements for the test, so I replaced it with the address of one of Google's mail servers.

I'll submit a separate PR for the change related to the newer c-ares.

Scott K