### PR TITLE
Update test_idna_encoding_query_a with new errno to align to new c-ares version

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -569,7 +569,7 @@ class DNSTest(unittest.TestCase):
         # try encoding it as utf-8
         self.channel.query(host.encode(), pycares.QUERY_TYPE_A, cb)
         self.wait()
-        self.assertEqual(self.errorno, pycares.errno.ARES_ENOTFOUND)
+        self.assertEqual(self.errorno, pycares.errno.ARES_EBADNAME)
         self.assertEqual(self.result, None)
         # use it as is (it's IDNA encoded internally)
         self.channel.query(host, pycares.QUERY_TYPE_A, cb)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -569,8 +569,8 @@ class DNSTest(unittest.TestCase):
         # try encoding it as utf-8
         self.channel.query(host.encode(), pycares.QUERY_TYPE_A, cb)
         self.wait()
-        # ARES_EBADNAME correct for c-ares 1.24 and ARES_ETIMEOUT for 1.18
-        if self.errorno == pycares.errno.ARES_ETIMEOUT:
+        # ARES_EBADNAME correct for c-ares 1.24 and ARES_ENOTFOUND for 1.18
+        if self.errorno == pycares.errno.ARES_ENOTFOUND:
             self.errorno = pycares.errno.ARES_EBADNAME
         self.assertEqual(self.errorno, pycares.errno.ARES_EBADNAME)
         self.assertEqual(self.result, None)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -569,6 +569,9 @@ class DNSTest(unittest.TestCase):
         # try encoding it as utf-8
         self.channel.query(host.encode(), pycares.QUERY_TYPE_A, cb)
         self.wait()
+        # ARES_EBADNAME correct for c-ares 1.24 and ARES_ETIMEOUT for 1.18
+        if self.errorno == pycares.errno.ARES_ETIMEOUT:
+            self.errorno = pycares.errno.ARES_EBADNAME
         self.assertEqual(self.errorno, pycares.errno.ARES_EBADNAME)
         self.assertEqual(self.result, None)
         # use it as is (it's IDNA encoded internally)


### PR DESCRIPTION
See https://github.com/saghul/pycares/issues/193

With this change, all tests pass with c-ares 1.24 (but will fail with 1.18).