### PR TITLE
Do not define HAVE_GETSERVBYPORT_R for platforms Android, Cygwin, Darwin

### DIFF
--- a/deps/build-config/config_android/ares_config.h
+++ b/deps/build-config/config_android/ares_config.h
@@ -46,12 +46,6 @@
 /* Define to the type of arg 7 for getnameinfo. */
 #define GETNAMEINFO_TYPE_ARG7 int
 
-/* Specifies the number of arguments to getservbyport_r */
-#define GETSERVBYPORT_R_ARGS 6
-
-/* Specifies the size of the buffer to pass to getservbyport_r */
-#define GETSERVBYPORT_R_BUFSIZE 4096
-
 /* Define to 1 if you have AF_INET6. */
 #define HAVE_AF_INET6 1
 
@@ -126,9 +120,6 @@
 
 /* Define to 1 if you have the getnameinfo function. */
 #define HAVE_GETNAMEINFO 1
-
-/* Define to 1 if you have the getservbyport_r function. */
-#define HAVE_GETSERVBYPORT_R 1
 
 /* Define to 1 if you have the `gettimeofday' function. */
 #define HAVE_GETTIMEOFDAY 1

--- a/deps/build-config/config_cygwin/ares_config.h
+++ b/deps/build-config/config_cygwin/ares_config.h
@@ -43,12 +43,6 @@
 /* Define to the type of arg 7 for getnameinfo. */
 #define GETNAMEINFO_TYPE_ARG7 int
 
-/* Specifies the number of arguments to getservbyport_r */
-/* #undef GETSERVBYPORT_R_ARGS */
-
-/* Specifies the size of the buffer to pass to getservbyport_r */
-/* #undef GETSERVBYPORT_R_BUFSIZE */
-
 /* Define to 1 if you have AF_INET6. */
 #define HAVE_AF_INET6 1
 
@@ -117,9 +111,6 @@
 
 /* Define to 1 if you have the getnameinfo function. */
 #define HAVE_GETNAMEINFO 1
-
-/* Define to 1 if you have the getservbyport_r function. */
-/* #undef HAVE_GETSERVBYPORT_R */
 
 /* Define to 1 if you have the `gettimeofday' function. */
 #define HAVE_GETTIMEOFDAY 1

--- a/deps/build-config/config_darwin/ares_config.h
+++ b/deps/build-config/config_darwin/ares_config.h
@@ -46,12 +46,6 @@
 /* Define to the type of arg 7 for getnameinfo. */
 #define GETNAMEINFO_TYPE_ARG7 int
 
-/* Specifies the number of arguments to getservbyport_r */
-/* #undef GETSERVBYPORT_R_ARGS */
-
-/* Specifies the size of the buffer to pass to getservbyport_r */
-/* #undef GETSERVBYPORT_R_BUFSIZE */
-
 /* Define to 1 if you have AF_INET6. */
 #define HAVE_AF_INET6 1
 
@@ -126,9 +120,6 @@
 
 /* Define to 1 if you have the getnameinfo function. */
 #define HAVE_GETNAMEINFO 1
-
-/* Define to 1 if you have the getservbyport_r function. */
-/* #undef HAVE_GETSERVBYPORT_R */
 
 /* Define to 1 if you have the `gettimeofday' function. */
 #define HAVE_GETTIMEOFDAY 1


### PR DESCRIPTION
This PR fix a long standing issue which Android build keep failing due to undefined getservbyport_r in bionic libc.

I think you can close all Android issues for good like #191 since it obviously a user mistake.