### PR TITLE
Add event thread support

### DIFF
--- a/docs/channel.rst
+++ b/docs/channel.rst
@@ -41,6 +41,17 @@
     :param callable sock_state_cb: A callback function to be invoked when a
         socket changes state. Callback signature: ``sock_state_cb(self, fd, readable, writable)``
 
+        This option is mutually exclusive with the ``event_thread`` option.
+
+    :param bool event_thread: If set to True, c-ares will use its own thread
+        to process events. This is the recommended way to use c-ares, as it
+        allows for automatic reinitialization of the channel when the
+        system resolver configuration changes. Verify that c-ares was
+        compiled with thread-safety by calling :py:func:`ares_threadsafety`
+        before using this option.
+
+        This option is mutually exclusive with the ``sock_state_cb`` option.
+
     :param int socket_send_buffer_size: Size for the created socket's send buffer.
 
     :param int socket_receive_buffer_size: Size for the created socket's receive buffer.

--- a/docs/pycares.rst
+++ b/docs/pycares.rst
@@ -13,6 +13,16 @@
     `c-ares source code
     <http://github.com/bagder/c-ares>`_.
 
+ares_threadsafety
+=================
+
+.. py:function:: ares_threadsafety()
+
+    Check if c-ares was compiled with thread safety support.
+
+    :returns: True if thread-safe, False otherwise.
+    :rtype: bool
+
 
 Objects
 *******

--- a/setup_cares.py
+++ b/setup_cares.py
@@ -168,7 +168,7 @@ class cares_build_ext(build_ext):
                 self.compiler.define_macro('HAVE_EPOLL', 1)
                 self.compiler.define_macro('HAVE_SYS_EPOLL_H', 1)
                 self.compiler.define_macro('HAVE_FCNTL_H', 1)
-            if hasattr(select, 'select'):
+            if hasattr(select, 'select') and sys.platform != 'win32':
                 self.compiler.define_macro('HAVE_PIPE', 1)
             self.extensions[0].sources += cares_sources
 

--- a/setup_cares.py
+++ b/setup_cares.py
@@ -152,6 +152,7 @@ class cares_build_ext(build_ext):
         if use_system_lib:
             self.compiler.add_library('cares')
         else:
+            self.compiler.define_macro('CARES_THREADS', 1)
             self.compiler.define_macro('CARES_STATICLIB', 1)
             self.extensions[0].sources += cares_sources
 

--- a/setup_cares.py
+++ b/setup_cares.py
@@ -168,7 +168,7 @@ class cares_build_ext(build_ext):
                 self.compiler.define_macro('HAVE_EPOLL', 1)
                 self.compiler.define_macro('HAVE_SYS_EPOLL_H', 1)
                 self.compiler.define_macro('HAVE_FCNTL_H', 1)
-            if hasattr(select, 'select') and sys.platform != 'win32':
+            if hasattr(os, 'pipe') and sys.platform != 'win32':
                 self.compiler.define_macro('HAVE_PIPE', 1)
             self.extensions[0].sources += cares_sources
 

--- a/setup_cares.py
+++ b/setup_cares.py
@@ -1,6 +1,7 @@
 
 import os
 import sys
+import select
 
 from setuptools.command.build_ext import build_ext
 
@@ -154,6 +155,21 @@ class cares_build_ext(build_ext):
         else:
             self.compiler.define_macro('CARES_THREADS', 1)
             self.compiler.define_macro('CARES_STATICLIB', 1)
+            if hasattr(select, 'poll'):
+                self.compiler.define_macro('HAVE_POLL', 1)
+                self.compiler.define_macro('HAVE_POLL_H', 1)
+            if hasattr(select, 'kqueue'):
+                self.compiler.define_macro('HAVE_KQUEUE', 1)
+                self.compiler.define_macro('HAVE_SYS_TYPES_H', 1)
+                self.compiler.define_macro('HAVE_SYS_EVENT_H', 1)
+                self.compiler.define_macro('HAVE_SYS_TIME_H', 1)
+                self.compiler.define_macro('HAVE_FCNTL_H', 1)
+            if hasattr(select, 'epoll'):
+                self.compiler.define_macro('HAVE_EPOLL', 1)
+                self.compiler.define_macro('HAVE_SYS_EPOLL_H', 1)
+                self.compiler.define_macro('HAVE_FCNTL_H', 1)
+            if hasattr(select, 'select'):
+                self.compiler.define_macro('HAVE_PIPE', 1)
             self.extensions[0].sources += cares_sources
 
         build_ext.build_extensions(self)

--- a/src/_cffi_src/build_cares.py
+++ b/src/_cffi_src/build_cares.py
@@ -245,29 +245,29 @@ typedef enum {
 } ares_evsys_t;
 
 struct ares_options {
-  int            flags;
-  int            timeout; /* in seconds or milliseconds, depending on options */
-  int            tries;
-  int            ndots;
+  int flags;
+  int timeout; /* in seconds or milliseconds, depending on options */
+  int tries;
+  int ndots;
   unsigned short udp_port; /* host byte order */
   unsigned short tcp_port; /* host byte order */
-  int            socket_send_buffer_size;
-  int            socket_receive_buffer_size;
-  struct in_addr    *servers;
-  int                nservers;
-  char             **domains;
-  int                ndomains;
-  char              *lookups;
+  int socket_send_buffer_size;
+  int socket_receive_buffer_size;
+  struct in_addr *servers;
+  int nservers;
+  char **domains;
+  int ndomains;
+  char *lookups;
   ares_sock_state_cb sock_state_cb;
-  void              *sock_state_cb_data;
-  struct apattern   *sortlist;
-  int                nsort;
-  int                ednspsz;
-  char              *resolvconf_path;
-  char              *hosts_path;
-  int                udp_max_queries;
-  int                maxtimeout; /* in milliseconds */
-  unsigned int qcache_max_ttl;   /* Maximum TTL for query cache, 0=disabled */
+  void *sock_state_cb_data;
+  struct apattern *sortlist;
+  int nsort;
+  int ednspsz;
+  char *resolvconf_path;
+  char *hosts_path;
+  int udp_max_queries;
+  int maxtimeout; /* in milliseconds */
+  unsigned int qcache_max_ttl; /* Maximum TTL for query cache, 0=disabled */
   ares_evsys_t evsys;
   struct ares_server_failover_options server_failover_opts;
   ...;

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -374,6 +374,8 @@ class Channel:
         if sock_state_cb:
             if not callable(sock_state_cb):
                 raise TypeError("sock_state_cb is not callable")
+            if event_thread:
+                raise RuntimeError("sock_state_cb and event_thread cannot be used together")
 
             userdata = _ffi.new_handle(sock_state_cb)
 
@@ -387,6 +389,8 @@ class Channel:
         if event_thread:
             if not ares_threadsafety():
                 raise RuntimeError("c-ares is not built with thread safety")
+            if sock_state_cb:
+                raise RuntimeError("sock_state_cb and event_thread cannot be used together")
             optmask = optmask |  _lib.ARES_OPT_EVENT_THREAD
             options.evsys = _lib.ARES_EVSYS_DEFAULT
 

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -864,7 +864,12 @@ class ares_addrinfo_result(AresResult):
 
 
 def ares_threadsafety() -> bool:
-    """Check if c-ares is thread safe."""
+    """
+    Check if c-ares was compiled with thread safety support.
+
+    :return: True if thread-safe, False otherwise.
+    :rtype: bool
+    """
     return bool(_lib.ares_threadsafety())
 
 __all__ = (


### PR DESCRIPTION
The aiodns counter part is https://github.com/aio-libs/aiodns/pull/145

The event thread is now the [recommended way -- see Event Thread example (recommended)](https://c-ares.org/docs.html) to run c-ares (per their docs) as it ensures that if the system configuration changes, c-ares now re-inits the channel automatically.