### PR TITLE
Cancel previous CI jobs on pull request update

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -2,6 +2,10 @@ name: Build Wheels
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     uses: ./.github/workflows/run-cibuildwheel.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}


### PR DESCRIPTION
In #221 I did a lot of pushes to figure out what had changed between versions. The previous jobs kept running and the CI got tied up.