### PR TITLE
Pin Python version to 3.13.3 to avoid Windows build error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13.3']
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Fixes: https://github.com/saghul/pycares/issues/234