### PR TITLE
Add read & write process_fd functions

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -609,6 +609,12 @@ class Channel:
     def process_fd(self, read_fd: int, write_fd: int) -> None:
         _lib.ares_process_fd(self._channel[0], _ffi.cast("ares_socket_t", read_fd), _ffi.cast("ares_socket_t", write_fd))
 
+    def process_read_fd(self, read_fd:int) -> None:
+        _lib.ares_process_fd(self._channel[0], _ffi.cast("ares_socket_t", read_fd), _ffi.cast("ares_socket_t", ARES_SOCKET_BAD))
+
+    def process_write_fd(self, write_fd:int) -> None:
+        _lib.ares_process_fd(self._channel[0], _ffi.cast("ares_socket_t", ARES_SOCKET_BAD), _ffi.cast("ares_socket_t", write_fd))
+
     def timeout(self, t = None):
         maxtv = _ffi.NULL
         tv = _ffi.new("struct timeval*")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -36,9 +36,9 @@ class DNSTest(unittest.TestCase):
                 continue
             rlist, wlist, xlist = select.select(read_fds, write_fds, [], timeout)
             for fd in rlist:
-                self.channel.process_fd(fd, pycares.ARES_SOCKET_BAD)
+                self.channel.process_read_fd(fd)
             for fd in wlist:
-                self.channel.process_fd(pycares.ARES_SOCKET_BAD, fd)
+                self.channel.process_write_fd(fd)
 
     def assertNoError(self, errorno):
         if errorno == pycares.errno.ARES_ETIMEOUT and self.is_ci:


### PR DESCRIPTION
So recently I actually started to write my own [cython version of this library](https://github.com/Vizonex/cyares) and in doing so I came up with an idea to make it easier to use the socket callbacks.  So instead of users needing to use `ARES_SOCKET_BAD` I made 2 functions that can be used to either process either a read or write file descriptor only. I'll be adding these changes to a future pull request to aiodns since the other reviewers didn't like that I accidently messed around with coverage. (I need to remember to close that [pull request](https://github.com/aio-libs/aiodns/pull/172) and open a new one if these changes get accepted and later updated)

Basically having these should allow users using an event loop to do something like this, this is what I wrote for my version of c-ares and I wanted aiodns to do the same with this library so that ARES_SOCKET_BAD doesn't have to be passed through to the different callbacks. 

If you think I should add in sphinx doc strings to this library as well I would be happy to do so.

```python

def _sock_state_cb(self, fd: int, readable: bool, writable: bool) -> None:
        if readable or writable:
            if readable:
                self.loop.add_reader(
                    fd, self._channel.process_read_fd, fd
                )
                self._read_fds.add(fd)
            if writable:
                self.loop.add_writer(
                    fd, self._channel.process_write_fd, fd
                )
                self._write_fds.add(fd)
            if self._timer is None:
                self._start_timer()

```


