### PR TITLE
Idna resource reduction security check

### DIFF
--- a/src/pycares/utils.py
+++ b/src/pycares/utils.py
@@ -27,6 +27,10 @@ def maybe_str(data):
 
 
 def parse_name_idna2008(name: str) -> str:
+    if len(name) > 255:
+        raise RuntimeError(
+            f"domains can only be 253 characters in length not {len(name)}"
+        )
     parts = name.split('.')
     r = []
     for part in parts:

--- a/src/pycares/utils.py
+++ b/src/pycares/utils.py
@@ -27,15 +27,15 @@ def maybe_str(data):
 
 
 def parse_name_idna2008(name: str) -> str:
-    if len(name) > 255:
-        raise RuntimeError(
-            f"domains can only be 253 characters in length not {len(name)}"
-        )
     parts = name.split('.')
     r = []
     for part in parts:
         if part.isascii():
             r.append(part.encode('ascii'))
+        elif len(part) > 253:
+            raise RuntimeError(
+                f"domains can only be 253 characters in length not {len(name)}"
+            )
         else:
             r.append(idna2008.encode(part))
     return b'.'.join(r)


### PR DESCRIPTION
There's a small possibility that this library is vulnerable to [CVE-2024-3651](https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h) since pycares allows versions of idna that are lower than 3.7 to be used. I have added in a special check to ensure that this resource attack will never happen since specially crafted inputs by an attacker can be a future problem to someone who may for example write a DNS website with python only to later have an attacker launch a very sophisticated payload. Domains can only be a size of 253 characters which is the maximum so knowing that I added in a security check to say that if any part is greater than 253 raise a `RuntimeError`. If you think I should put this check somewhere else in the function please let me know.