### PR TITLE
Fix discrepancies in struct timeval size

### DIFF
--- a/src/_cffi_src/build_cares.py
+++ b/src/_cffi_src/build_cares.py
@@ -35,6 +35,7 @@ struct in6_addr {
 struct timeval {
     time_t      tv_sec;
     suseconds_t tv_usec;
+    ...;
 };
 
 struct hostent {


### PR DESCRIPTION
Fixes: https://github.com/saghul/pycares/issues/260