### PR TITLE
enable uploading pycares wheels to the release page

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: write
+
 jobs:
   build_wheels:
     uses: ./.github/workflows/run-cibuildwheel.yml
@@ -13,6 +16,25 @@ jobs:
 
   build_sdist:
     uses: ./.github/workflows/run-sdist.yml
+
+  upload_github:
+    needs: [build_wheels, build_sdist]
+    if: github.event_name == 'release' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+      
+      # This will simply modify the given github release
+      # allowing for wheels to be uploaded to github's release
+      # page automatically.
+      - name: Upload Wheels To GitHub Release Page
+        uses: softprops/action-gh-release@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: dist/*
 
   upload_pypi:
     needs: [build_wheels, build_sdist]


### PR DESCRIPTION
So something I figured out today with some of my other packages was uploading wheels onto the release page if a release was made. I wanted to try doing that here also since I think it come in handy incase something like pypi were to be down or under maintenance but the wheels were already successfully made beforehand.

I have an example where I have package for using the wepoll C Library in python which I tested around an hour ago along with a new release for it https://github.com/Vizonex/pywepoll/releases/tag/v0.3.5
