### PR TITLE
build: riscv64 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ version = {attr = "pycares._version.__version__"}
 build = "cp3*"
 
 [tool.cibuildwheel.linux]
-archs = ["auto", "aarch64", "ppc64le", "s390x"]
+archs = ["auto", "aarch64", "ppc64le", "riscv64", "s390x"]
 before-all = """
 set -eux
 # musllinux_*


### PR DESCRIPTION
* cibuildwheel configuration add riscv64 in pyproject.toml

Resolves: saghul/pycares#308