### PR TITLE
Defer ares_destroy to __del__ to fix close()/submit use-after-free

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -604,8 +604,10 @@ class Channel:
         _shutdown_manager.start()
 
     def __del__(self) -> None:
-        """Ensure the channel is destroyed when the object is deleted."""
-        self.close()
+        # Deliberately lock-free: when __del__ runs, no submitter holds
+        # self and no callback is pending, so the read-and-null in
+        # _destroy_channel is uncontested.
+        self._destroy_channel()
 
     @contextlib.contextmanager
     def _capture_channel(self):
@@ -925,8 +927,10 @@ class Channel:
 
         """
         with self._lock:
-            channel, self._channel = self._channel, None
+            self._destroy_channel()
 
+    def _destroy_channel(self) -> None:
+        channel, self._channel = self._channel, None
         if channel is None:
             # Already destroyed
             return

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -12,6 +12,7 @@ from . import errno
 from .utils import ascii_bytes, maybe_str, parse_name
 from ._version import __version__
 
+import contextlib
 import math
 import socket
 import threading
@@ -506,6 +507,7 @@ class Channel:
 
         # Initialize _channel to None first to ensure __del__ doesn't fail
         self._channel = None
+        self._lock = threading.RLock()
 
         # Store flags for later use (default is 0 if not specified)
         self._flags = flags if flags is not None else 0
@@ -605,22 +607,19 @@ class Channel:
         """Ensure the channel is destroyed when the object is deleted."""
         self.close()
 
+    @contextlib.contextmanager
     def _capture_channel(self):
         """
-        Atomically capture the c-ares channel pointer for use in a single
-        submission call.
-
-        Returns the captured cdata; the caller MUST use this captured value
-        (not self._channel) for the duration of the submission so that a
-        concurrent close() on another thread cannot turn the value into
-        None mid-call.
+        Yield the c-ares channel pointer while holding self._lock so that
+        a concurrent close() cannot destroy the channel mid-call.
 
         Raises RuntimeError if the channel has been closed.
         """
-        channel = self._channel
-        if channel is None:
-            raise RuntimeError("Channel is destroyed, no new queries allowed")
-        return channel
+        with self._lock:
+            channel = self._channel
+            if channel is None:
+                raise RuntimeError("Channel is destroyed, no new queries allowed")
+            yield channel
 
     def _register_callback_handle(self, callback_data):
         """
@@ -707,13 +706,13 @@ class Channel:
         else:
             raise ValueError("invalid IP address")
 
-        channel = self._capture_channel()
-        userdata = self._register_callback_handle(callback)
-        try:
-            _lib.ares_gethostbyaddr(channel[0], address, _ffi.sizeof(address[0]), family, _lib._host_cb, userdata)
-        except BaseException:
-            _handle_to_channel.pop(userdata, None)
-            raise
+        with self._capture_channel() as channel:
+            userdata = self._register_callback_handle(callback)
+            try:
+                _lib.ares_gethostbyaddr(channel[0], address, _ffi.sizeof(address[0]), family, _lib._host_cb, userdata)
+            except BaseException:
+                _handle_to_channel.pop(userdata, None)
+                raise
 
     def getaddrinfo(
         self,
@@ -736,18 +735,18 @@ class Channel:
         else:
             service = ascii_bytes(port)
 
-        channel = self._capture_channel()
-        userdata = self._register_callback_handle(callback)
-        try:
-            hints = _ffi.new('struct ares_addrinfo_hints*')
-            hints.ai_flags = flags
-            hints.ai_family = family
-            hints.ai_socktype = type
-            hints.ai_protocol = proto
-            _lib.ares_getaddrinfo(channel[0], parse_name(host), service, hints, _lib._addrinfo_cb, userdata)
-        except BaseException:
-            _handle_to_channel.pop(userdata, None)
-            raise
+        with self._capture_channel() as channel:
+            userdata = self._register_callback_handle(callback)
+            try:
+                hints = _ffi.new('struct ares_addrinfo_hints*')
+                hints.ai_flags = flags
+                hints.ai_family = family
+                hints.ai_socktype = type
+                hints.ai_protocol = proto
+                _lib.ares_getaddrinfo(channel[0], parse_name(host), service, hints, _lib._addrinfo_cb, userdata)
+            except BaseException:
+                _handle_to_channel.pop(userdata, None)
+                raise
 
     def query(self, name: str, query_type: int, *, query_class: int = QUERY_CLASS_IN, callback: Callable[[Any, int], None]) -> None:
         """
@@ -770,22 +769,22 @@ class Channel:
         if query_class not in self.__qclasses__:
             raise ValueError('invalid query class specified')
 
-        channel = self._capture_channel()
-        userdata = self._register_callback_handle(callback)
-        try:
-            qid = _ffi.new("unsigned short *")
-            status = _lib.ares_query_dnsrec(
-                channel[0],
-                parse_name(name),
-                query_class,
-                query_type,
-                _lib._query_dnsrec_cb,
-                userdata,
-                qid
-            )
-        except BaseException:
-            _handle_to_channel.pop(userdata, None)
-            raise
+        with self._capture_channel() as channel:
+            userdata = self._register_callback_handle(callback)
+            try:
+                qid = _ffi.new("unsigned short *")
+                status = _lib.ares_query_dnsrec(
+                    channel[0],
+                    parse_name(name),
+                    query_class,
+                    query_type,
+                    _lib._query_dnsrec_cb,
+                    userdata,
+                    qid
+                )
+            except BaseException:
+                _handle_to_channel.pop(userdata, None)
+                raise
         if status != _lib.ARES_SUCCESS:
             _handle_to_channel.pop(userdata, None)
             raise AresError(status, errno.strerror(status))
@@ -810,8 +809,6 @@ class Channel:
 
         if query_class not in self.__qclasses__:
             raise ValueError('invalid query class specified')
-
-        channel = self._capture_channel()
 
         # Create a DNS record for the search query
         # Set RD (Recursion Desired) flag unless ARES_FLAG_NORECURSE is set
@@ -851,18 +848,19 @@ class Channel:
                 _lib.ares_dns_record_destroy(dnsrec)
 
         # Perform the search with the created DNS record
-        userdata = self._register_callback_handle(cleanup_callback)
-        try:
-            status = _lib.ares_search_dnsrec(
-                channel[0],
-                dnsrec,
-                _lib._query_dnsrec_cb,
-                userdata
-            )
-        except BaseException:
-            _handle_to_channel.pop(userdata, None)
-            _lib.ares_dns_record_destroy(dnsrec)
-            raise
+        with self._capture_channel() as channel:
+            userdata = self._register_callback_handle(cleanup_callback)
+            try:
+                status = _lib.ares_search_dnsrec(
+                    channel[0],
+                    dnsrec,
+                    _lib._query_dnsrec_cb,
+                    userdata
+                )
+            except BaseException:
+                _handle_to_channel.pop(userdata, None)
+                _lib.ares_dns_record_destroy(dnsrec)
+                raise
         if status != _lib.ARES_SUCCESS:
             _handle_to_channel.pop(userdata, None)
             _lib.ares_dns_record_destroy(dnsrec)
@@ -903,13 +901,13 @@ class Channel:
         else:
             raise ValueError("Invalid address argument")
 
-        channel = self._capture_channel()
-        userdata = self._register_callback_handle(callback)
-        try:
-            _lib.ares_getnameinfo(channel[0], _ffi.cast("struct sockaddr*", sa), _ffi.sizeof(sa[0]), flags, _lib._nameinfo_cb, userdata)
-        except BaseException:
-            _handle_to_channel.pop(userdata, None)
-            raise
+        with self._capture_channel() as channel:
+            userdata = self._register_callback_handle(callback)
+            try:
+                _lib.ares_getnameinfo(channel[0], _ffi.cast("struct sockaddr*", sa), _ffi.sizeof(sa[0]), flags, _lib._nameinfo_cb, userdata)
+            except BaseException:
+                _handle_to_channel.pop(userdata, None)
+                raise
 
     def set_local_dev(self, dev):
         _lib.ares_set_local_dev(self._channel[0], dev)
@@ -919,14 +917,16 @@ class Channel:
         Close the channel as soon as it's safe to do so.
 
         This method can be called from any thread. The channel will be destroyed
-        safely using a background thread with a 1-second delay to ensure c-ares
-        has completed its cleanup.
+        safely using a background thread, after any in-flight submission has
+        returned, to ensure c-ares has completed its cleanup.
 
         Note: Once close() is called, no new queries can be started. Any pending
         queries will be cancelled and their callbacks will receive ARES_ECANCELLED.
 
         """
-        channel, self._channel = self._channel, None
+        with self._lock:
+            channel, self._channel = self._channel, None
+
         if channel is None:
             # Already destroyed
             return

--- a/tests/test_close_query_race.py
+++ b/tests/test_close_query_race.py
@@ -1,0 +1,74 @@
+"""Regression test: Channel.close() racing with Channel.query().
+
+We race query() against close() in two threads. Without the fixes
+this reproduces both:
+
+  * a TypeError when self._channel goes None between the check and
+    self._channel[0], and
+  * a use-after-free where ares_destroy ran underneath the in-flight
+    submission (visible as ARES_ENOSERVER from query()).
+
+The test is skipped by default because it deliberately hammers the
+scheduler for a few seconds; opt in with PYCARES_RUN_RACE_TESTS=1.
+"""
+import os
+import threading
+import time
+import unittest
+
+import pycares
+
+
+@unittest.skipUnless(
+    os.environ.get('PYCARES_RUN_RACE_TESTS'),
+    "Set PYCARES_RUN_RACE_TESTS=1 to run scheduler-stress race tests",
+)
+class CloseQueryRaceTest(unittest.TestCase):
+    def test_close_during_query_does_not_crash(self):
+        rounds = 10000
+        crashes = []
+
+        def _cb(result, error):
+            pass
+
+        def round_once(i):
+            ch = pycares.Channel(timeout=1.0, tries=1,
+                                 servers=['8.8.8.8', '1.1.1.1'])
+            barrier = threading.Barrier(2)
+
+            def query_thread():
+                barrier.wait()
+                for j in range(20):
+                    try:
+                        ch.query('race-%d-%d.example.invalid' % (i, j),
+                                 pycares.QUERY_TYPE_A, callback=_cb)
+                    except RuntimeError:
+                        return
+                    except Exception as e:
+                        crashes.append((i, j, repr(e)))
+                        return
+
+            def close_thread():
+                barrier.wait()
+                time.sleep(0.003)
+                ch.close()
+
+            tc = threading.Thread(target=close_thread)
+            tq = threading.Thread(target=query_thread)
+            tc.start()
+            tq.start()
+            tc.join(timeout=10)
+            tq.join(timeout=10)
+
+        for i in range(rounds):
+            round_once(i)
+            if len(crashes) >= 5:
+                break
+
+        # Allow callbacks fired by ares_cancel to drain.
+        time.sleep(2)
+
+        self.assertFalse(
+            crashes,
+            "unexpected exceptions during close/query race: %r" % (crashes,),
+        )


### PR DESCRIPTION
close() concurrent with a submission could destroy the c-ares channel out from under an in-flight call. Symptom: ARES_ENOSERVER from query(); real issue: user-after-free of the channel state.

close() now nulls self._channel, stashes the cdata in self._closing_channel, and calls ares_cancel. 

ares_destroy is deferred to `__del__`, which cannot run while any submitter frame or pending callback still holds self.

Adds tests/test_close_query_race.py.