### PR TITLE
Fix handle leak in c-ares submission methods

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -812,6 +812,8 @@ class Channel:
         if query_class not in self.__qclasses__:
             raise ValueError('invalid query class specified')
 
+        channel = self._capture_channel()
+
         # Create a DNS record for the search query
         # Set RD (Recursion Desired) flag unless ARES_FLAG_NORECURSE is set
         dns_flags = 0 if (self._flags & _lib.ARES_FLAG_NORECURSE) else _lib.ARES_FLAG_RD
@@ -850,11 +852,6 @@ class Channel:
                 _lib.ares_dns_record_destroy(dnsrec)
 
         # Perform the search with the created DNS record
-        try:
-            channel = self._capture_channel()
-        except BaseException:
-            _lib.ares_dns_record_destroy(dnsrec)
-            raise
         userdata = self._register_callback_handle(cleanup_callback)
         try:
             status = _lib.ares_search_dnsrec(

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -606,27 +606,30 @@ class Channel:
         """Ensure the channel is destroyed when the object is deleted."""
         self.close()
 
-    def _create_callback_handle(self, callback_data):
+    def _capture_channel(self):
         """
-        Create a callback handle and register it for tracking.
+        Atomically capture the c-ares channel pointer for use in a single
+        submission call.
 
-        This ensures that:
-        1. The callback data is wrapped in a CFFI handle
-        2. The handle is mapped to this channel to keep it alive
+        Returns the captured cdata; the caller MUST use this captured value
+        (not self._channel) for the duration of the submission so that a
+        concurrent close() on another thread cannot turn the value into
+        None mid-call.
 
-        Args:
-            callback_data: The data to pass to the callback (usually a callable or tuple)
-
-        Returns:
-            The CFFI handle that can be passed to C functions
-
-        Raises:
-            RuntimeError: If the channel is destroyed
-
+        Raises RuntimeError if the channel has been closed.
         """
-        if self._channel is None:
+        channel = self._channel
+        if channel is None:
             raise RuntimeError("Channel is destroyed, no new queries allowed")
+        return channel
 
+    def _register_callback_handle(self, callback_data):
+        """
+        Wrap callback_data in a cffi handle and register it so that it (and
+        the Channel) stay alive until the c-ares callback fires. Callers
+        MUST pop the handle from _handle_to_channel on any exception path
+        before the c-ares callback could ever observe it.
+        """
         userdata = _ffi.new_handle(callback_data)
         _handle_to_channel[userdata] = self
         return userdata
@@ -705,8 +708,13 @@ class Channel:
         else:
             raise ValueError("invalid IP address")
 
-        userdata = self._create_callback_handle(callback)
-        _lib.ares_gethostbyaddr(self._channel[0], address, _ffi.sizeof(address[0]), family, _lib._host_cb, userdata)
+        channel = self._capture_channel()
+        userdata = self._register_callback_handle(callback)
+        try:
+            _lib.ares_gethostbyaddr(channel[0], address, _ffi.sizeof(address[0]), family, _lib._host_cb, userdata)
+        except BaseException:
+            _handle_to_channel.pop(userdata, None)
+            raise
 
     def getaddrinfo(
         self,
@@ -729,14 +737,18 @@ class Channel:
         else:
             service = ascii_bytes(port)
 
-        userdata = self._create_callback_handle(callback)
-
-        hints = _ffi.new('struct ares_addrinfo_hints*')
-        hints.ai_flags = flags
-        hints.ai_family = family
-        hints.ai_socktype = type
-        hints.ai_protocol = proto
-        _lib.ares_getaddrinfo(self._channel[0], parse_name(host), service, hints, _lib._addrinfo_cb, userdata)
+        channel = self._capture_channel()
+        userdata = self._register_callback_handle(callback)
+        try:
+            hints = _ffi.new('struct ares_addrinfo_hints*')
+            hints.ai_flags = flags
+            hints.ai_family = family
+            hints.ai_socktype = type
+            hints.ai_protocol = proto
+            _lib.ares_getaddrinfo(channel[0], parse_name(host), service, hints, _lib._addrinfo_cb, userdata)
+        except BaseException:
+            _handle_to_channel.pop(userdata, None)
+            raise
 
     def query(self, name: str, query_type: int, *, query_class: int = QUERY_CLASS_IN, callback: Callable[[Any, int], None]) -> None:
         """
@@ -759,17 +771,22 @@ class Channel:
         if query_class not in self.__qclasses__:
             raise ValueError('invalid query class specified')
 
-        userdata = self._create_callback_handle(callback)
-        qid = _ffi.new("unsigned short *")
-        status = _lib.ares_query_dnsrec(
-            self._channel[0],
-            parse_name(name),
-            query_class,
-            query_type,
-            _lib._query_dnsrec_cb,
-            userdata,
-            qid
-        )
+        channel = self._capture_channel()
+        userdata = self._register_callback_handle(callback)
+        try:
+            qid = _ffi.new("unsigned short *")
+            status = _lib.ares_query_dnsrec(
+                channel[0],
+                parse_name(name),
+                query_class,
+                query_type,
+                _lib._query_dnsrec_cb,
+                userdata,
+                qid
+            )
+        except BaseException:
+            _handle_to_channel.pop(userdata, None)
+            raise
         if status != _lib.ARES_SUCCESS:
             _handle_to_channel.pop(userdata, None)
             raise AresError(status, errno.strerror(status))
@@ -833,13 +850,23 @@ class Channel:
                 _lib.ares_dns_record_destroy(dnsrec)
 
         # Perform the search with the created DNS record
-        userdata = self._create_callback_handle(cleanup_callback)
-        status = _lib.ares_search_dnsrec(
-            self._channel[0],
-            dnsrec,
-            _lib._query_dnsrec_cb,
-            userdata
-        )
+        try:
+            channel = self._capture_channel()
+        except BaseException:
+            _lib.ares_dns_record_destroy(dnsrec)
+            raise
+        userdata = self._register_callback_handle(cleanup_callback)
+        try:
+            status = _lib.ares_search_dnsrec(
+                channel[0],
+                dnsrec,
+                _lib._query_dnsrec_cb,
+                userdata
+            )
+        except BaseException:
+            _handle_to_channel.pop(userdata, None)
+            _lib.ares_dns_record_destroy(dnsrec)
+            raise
         if status != _lib.ARES_SUCCESS:
             _handle_to_channel.pop(userdata, None)
             _lib.ares_dns_record_destroy(dnsrec)
@@ -880,8 +907,13 @@ class Channel:
         else:
             raise ValueError("Invalid address argument")
 
-        userdata = self._create_callback_handle(callback)
-        _lib.ares_getnameinfo(self._channel[0], _ffi.cast("struct sockaddr*", sa), _ffi.sizeof(sa[0]), flags, _lib._nameinfo_cb, userdata)
+        channel = self._capture_channel()
+        userdata = self._register_callback_handle(callback)
+        try:
+            _lib.ares_getnameinfo(channel[0], _ffi.cast("struct sockaddr*", sa), _ffi.sizeof(sa[0]), flags, _lib._nameinfo_cb, userdata)
+        except BaseException:
+            _handle_to_channel.pop(userdata, None)
+            raise
 
     def set_local_dev(self, dev):
         _lib.ares_set_local_dev(self._channel[0], dev)

--- a/tests/test_handle_leaks.py
+++ b/tests/test_handle_leaks.py
@@ -1,0 +1,64 @@
+"""Regression tests for handle leaks in _handle_to_channel.
+
+The submission methods register a cffi handle in the global
+_handle_to_channel dict before the c-ares call runs. If argument
+evaluation raises (for example parse_name() raising on an invalid IDNA
+name) the handle must still be popped, otherwise it (and the Channel
+reference it carries) leaks forever.
+"""
+import unittest
+
+import pycares
+from pycares import _handle_to_channel
+
+
+def _cb(result, error):
+    pass
+
+
+class HandleLeakTest(unittest.TestCase):
+    def setUp(self):
+        self.channel = pycares.Channel(
+            timeout=1.0, tries=1, servers=['8.8.8.8'],
+        )
+
+    def tearDown(self):
+        self.channel.close()
+
+    def test_query_does_not_leak_on_parse_name_failure(self):
+        before = len(_handle_to_channel)
+        with self.assertRaises(UnicodeError):
+            self.channel.query(
+                '\udc80bad', pycares.QUERY_TYPE_A, callback=_cb,
+            )
+        self.assertEqual(len(_handle_to_channel), before)
+
+    def test_search_does_not_leak_on_parse_name_failure(self):
+        before = len(_handle_to_channel)
+        with self.assertRaises(UnicodeError):
+            self.channel.search(
+                '\udc80bad', pycares.QUERY_TYPE_A, callback=_cb,
+            )
+        self.assertEqual(len(_handle_to_channel), before)
+
+    def test_getaddrinfo_does_not_leak_on_parse_name_failure(self):
+        before = len(_handle_to_channel)
+        with self.assertRaises(UnicodeError):
+            self.channel.getaddrinfo('\udc80bad', None, callback=_cb)
+        self.assertEqual(len(_handle_to_channel), before)
+
+    def test_gethostbyaddr_does_not_leak_on_invalid_ip(self):
+        before = len(_handle_to_channel)
+        with self.assertRaises(ValueError):
+            self.channel.gethostbyaddr('not-an-ip', callback=_cb)
+        self.assertEqual(len(_handle_to_channel), before)
+
+    def test_getnameinfo_does_not_leak_on_invalid_ip(self):
+        before = len(_handle_to_channel)
+        with self.assertRaises(ValueError):
+            self.channel.getnameinfo(('not-an-ip', 80), 0, callback=_cb)
+        self.assertEqual(len(_handle_to_channel), before)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
If parse_name() raises while evaluating arguments to a c-ares call, the callback handle was already in _handle_to_channel and leaked forever.

Split the helper into _capture_channel() and _register_callback_handle(), and wrap each c-ares call in try/except that pops the handle. Also removes a TypeError race where self._channel could go None between the check and self._channel[0].

Adds tests/test_handle_leaks.py.