### PR TITLE
implement ares_set_server_state_callback

### DIFF
--- a/src/_cffi_src/build_cares.py
+++ b/src/_cffi_src/build_cares.py
@@ -290,6 +290,10 @@ typedef int... ares_socklen_t;
 #define ARES_AI_CANONIDN                ...
 #define ARES_AI_MASK ...
 
+#define ARES_SERV_STATE_UDP ...
+#define ARES_SERV_STATE_TCP ...
+
+
 #define ARES_LIB_INIT_ALL    ...
 
 #define ARES_SOCKET_BAD ...
@@ -376,6 +380,10 @@ typedef void (*ares_addrinfo_callback)(void *arg,
                                    int status,
                                    int timeouts,
                                    struct ares_addrinfo *res);
+
+typedef void (*ares_server_state_callback)(const char *server_string, 
+                                        ares_bool_t success, 
+                                        int flags, void *data);
 
 struct ares_channeldata;
 typedef struct ares_channeldata *ares_channel;
@@ -712,6 +720,10 @@ int ares_inet_pton(int af, const char *src, void *dst);
 ares_bool_t ares_threadsafety(void);
 
 ares_status_t ares_queue_wait_empty(ares_channel channel, int timeout_ms);
+
+void ares_set_server_state_callback(
+    ares_channel channel,
+    ares_server_state_callback cb, void *data);
 """
 
 CALLBACKS = """
@@ -740,6 +752,11 @@ extern "Python" void _addrinfo_cb(void *arg,
                                   int status,
                                   int timeouts,
                                   struct ares_addrinfo *res);
+
+extern "Python" void _server_state_cb(const char *server_string, 
+                                      ares_bool_t success, 
+                                      int flags, 
+                                      void *data);
 """
 
 INCLUDES = """

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -945,8 +945,7 @@ class Channel:
             self._destroy_channel()
 
     def _destroy_channel(self) -> None:
-        channel, self._channel = self._channel, None
-        if channel is None:
+        if self._channel is None:
             # Already destroyed
             return
 

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -986,9 +986,10 @@ class Channel:
         if not callable(callback):
             raise TypeError("a callable is required")
 
-        userdata = _ffi.new_handle(callback)
-        self._server_state_cb_handle = userdata
-        _lib.ares_set_server_state_callback(self._channel[0], _lib._server_state_cb, userdata)
+        with self._lock:
+            userdata = _ffi.new_handle(callback)
+            self._server_state_cb_handle = userdata
+            _lib.ares_set_server_state_callback(self._channel[0], _lib._server_state_cb, userdata)
 
 
 # DNS query result types - New dataclass-based API

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -79,6 +79,10 @@ QUERY_CLASS_HS = _lib.ARES_CLASS_HESOID
 QUERY_CLASS_NONE = _lib.ARES_CLASS_NONE
 QUERY_CLASS_ANY = _lib.ARES_CLASS_ANY
 
+# Server states 
+SERVER_STATE_UDP = _lib.ARES_SERV_STATE_UDP
+SERVER_STATE_TCP = _lib.ARES_SERV_STATE_TCP
+
 ARES_VERSION = maybe_str(_ffi.string(_lib.ares_version(_ffi.NULL)))
 PYCARES_ADDRTTL_SIZE = 256
 
@@ -172,6 +176,13 @@ def _addrinfo_cb(arg, status, timeouts, res):
 
     callback(result, status)
     _handle_to_channel.pop(arg, None)
+
+@_ffi.def_extern()
+def _server_state_cb(server_string, success, flags, data):
+    # same behavior as a socket state callback
+    server_state_cb = _ffi.from_handle(data)
+    server = maybe_str(_ffi.string(server_string))
+    server_state_cb(server, success == 1, flags)
 
 
 def _extract_opt_params(rr, key):
@@ -598,6 +609,9 @@ class Channel:
 
         if local_dev:
             self.set_local_dev(local_dev)
+        
+        # This gets set later...
+        self._server_state_cb_handle = None
 
         # Ensure the shutdown thread is started
         _shutdown_manager.start()
@@ -923,6 +937,23 @@ class Channel:
             return False
         else:
             raise AresError(r, errno.strerror(r))
+
+    def set_server_state_callback(self, callback: Callable[[str, bool, int], None]) -> None:
+        """
+        Set a callback that is notified when there are both successful and unsuccessful queries
+        it can even be used to monitor or trace the DNS servers being used by this active channel.
+
+        Args:
+            callback: callback containing the server string, 
+                success status and flag to indicate if the query 
+                was attempted over TCP or UDP.
+        """
+        if not callable(callback):
+            raise TypeError("a callable is required")
+
+        userdata = _ffi.new_handle(callback)
+        self._server_state_cb_handle = userdata
+        _lib.ares_set_server_state_callback(self._channel[0], _lib._server_state_cb, userdata)
 
 
 # DNS query result types - New dataclass-based API

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -451,7 +451,7 @@ class _ChannelShutdownManager:
         """Process channel destruction requests from the queue."""
         while True:
             # Block forever until we get a channel to destroy
-            channel, _ = self._queue.get()
+            channel, _ , _ = self._queue.get()
 
             # Cancel all pending queries - this will trigger callbacks with ARES_ECANCELLED
             _lib.ares_cancel(channel[0])
@@ -474,7 +474,7 @@ class _ChannelShutdownManager:
             self._thread = threading.Thread(target=self._run_safe_shutdown_loop, daemon=True)
             self._thread.start()
 
-    def destroy_channel(self, channel, sock_state_cb_handle) -> None:
+    def destroy_channel(self, channel, sock_state_cb_handle, server_state_cb_handle) -> None:
         """
         Schedule channel destruction on the background thread.
 
@@ -486,7 +486,7 @@ class _ChannelShutdownManager:
         from multiple threads. The background thread processes channels
         sequentially waiting for queries to end before each destruction.
         """
-        self._queue.put((channel, sock_state_cb_handle))
+        self._queue.put((channel, sock_state_cb_handle, server_state_cb_handle))
 
 
 # Global shutdown manager instance
@@ -921,7 +921,9 @@ class Channel:
 
         # Schedule channel destruction
         channel, self._channel = self._channel, None
-        _shutdown_manager.destroy_channel(channel, self._sock_state_cb_handle)
+        _shutdown_manager.destroy_channel(
+            channel, self._sock_state_cb_handle, self._server_state_cb_handle
+        )
 
     def wait(self, timeout: float=None) -> bool:
         """

--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -954,14 +954,10 @@ class Channel:
         # query callback.
 
         # Schedule channel destruction
-<<<<<<< HEAD
         channel, self._channel = self._channel, None
         _shutdown_manager.destroy_channel(
             channel, self._sock_state_cb_handle, self._server_state_cb_handle
         )
-=======
-        _shutdown_manager.destroy_channel(channel, self._sock_state_cb_handle)
->>>>>>> 96da7710dd7c798bed9a33efcf40ae110a31da89
 
     def wait(self, timeout: float=None) -> bool:
         """

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1233,6 +1233,28 @@ class ChannelCloseTest(unittest.TestCase):
         with self.assertRaises((RuntimeError, UnicodeError)):
             channel.query(large_domain_attack, pycares.QUERY_TYPE_A, callback=noop)
 
+    def test_server_state_cb(self):
+        channel = pycares.Channel(servers=["8.8.8.8"])
+
+        # we don't really care if the query decides to fail or not 
+        # we just want to ensure that server state callbacks trigger
+        # correctly.
+        called = False
+        def server_state_cb(server, success, flags):
+            nonlocal called
+            called = True
+            assert server == "8.8.8.8:53"
+            assert isinstance(success, bool)
+            assert isinstance(flags, int)
+
+        def noop(cb, status):
+            pass
+        
+        channel.set_server_state_callback(server_state_cb)
+        channel.query("www.google.com", pycares.QUERY_TYPE_A, callback=noop)
+        channel.wait()
+        assert called == True
+
 
 class EventThreadTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
I thought this would be a good function to implement here and I have a similar idea for cyares also. 

This function enables tracing server callbacks and figuring out which server succeeded and which ones do not and they enable seeing what protocol was used such as TCP or UDP. 

Some more information on `ares_set_server_state_callback` can be found in the [documentation](https://c-ares.org/docs/ares_set_server_state_callback.html). I this think would also do well with aiodns where the loop can create an asynchronous task for it when it has been called but I'll implement that in after pycares gets another update.
