### PR TITLE
Fix double-free of dnsrec in Channel.search()

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -850,33 +850,25 @@ class Channel:
             _lib.ares_dns_record_destroy(dnsrec)
             raise AresError(status, errno.strerror(status))
 
-        # Wrap callback to destroy DNS record after it's called
-        original_callback = callback
-        def cleanup_callback(result, error):
-            try:
-                original_callback(result, error)
-            finally:
-                # Clean up the DNS record after the callback completes
-                _lib.ares_dns_record_destroy(dnsrec)
-
-        # Perform the search with the created DNS record
-        with self._capture_channel() as channel:
-            userdata = self._register_callback_handle(cleanup_callback)
-            try:
-                status = _lib.ares_search_dnsrec(
-                    channel,
-                    dnsrec,
-                    _lib._query_dnsrec_cb,
-                    userdata
-                )
-            except BaseException:
-                _handle_to_channel.pop(userdata, None)
-                _lib.ares_dns_record_destroy(dnsrec)
-                raise
-        if status != _lib.ARES_SUCCESS:
-            _handle_to_channel.pop(userdata, None)
+        # dnsrec is only needed for this call (it's a const parameter); free
+        # it once ares_search_dnsrec() returns, regardless of outcome.
+        try:
+            with self._capture_channel() as channel:
+                userdata = self._register_callback_handle(callback)
+                try:
+                    status = _lib.ares_search_dnsrec(
+                        channel,
+                        dnsrec,
+                        _lib._query_dnsrec_cb,
+                        userdata
+                    )
+                except BaseException:
+                    _handle_to_channel.pop(userdata, None)
+                    raise
+            if status != _lib.ARES_SUCCESS:
+                raise AresError(status, errno.strerror(status))
+        finally:
             _lib.ares_dns_record_destroy(dnsrec)
-            raise AresError(status, errno.strerror(status))
 
     def set_local_ip(self, ip):
         addr4 = _ffi.new("struct in_addr*")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -643,6 +643,25 @@ class DNSTest(unittest.TestCase):
             # Error raised immediately - this is also valid
             self.assertEqual(e.args[0], pycares.errno.ARES_ENOTFOUND)
 
+    def test_search_onion(self):
+        # Regression test: ares_search_dnsrec() rejects ".onion" names
+        # synchronously (RFC 7686) and invokes the callback before
+        # returning its status. search() must not double-free the
+        # internal ares_dns_record_t in that case.
+        self.result, self.errorno = None, None
+
+        def cb(result, errorno):
+            self.result, self.errorno = result, errorno
+
+        try:
+            self.channel.search("foo.onion", pycares.QUERY_TYPE_A, callback=cb)
+            self.wait()
+            self.assertEqual(self.result, None)
+            self.assertEqual(self.errorno, pycares.errno.ARES_ENOTFOUND)
+        except pycares.AresError as e:
+            # Error raised immediately - this is also valid
+            self.assertEqual(e.args[0], pycares.errno.ARES_ENOTFOUND)
+
     def test_channel_nameservers(self):
         self.result, self.errorno = None, None
 

--- a/tests/test_handle_leaks.py
+++ b/tests/test_handle_leaks.py
@@ -59,6 +59,18 @@ class HandleLeakTest(unittest.TestCase):
             self.channel.getnameinfo(('not-an-ip', 80), 0, callback=_cb)
         self.assertEqual(len(_handle_to_channel), before)
 
+    def test_search_does_not_leak_dnsrec_on_closed_channel(self):
+        # Regression test: search() builds its own ares_dns_record_t before
+        # acquiring the channel. If the channel is already closed,
+        # _capture_channel() raises before that record is ever handed off
+        # to a callback, so search() must free it itself instead of leaking
+        # the native allocation.
+        self.channel.close()
+        before = len(_handle_to_channel)
+        with self.assertRaises(RuntimeError):
+            self.channel.search('example.com', pycares.QUERY_TYPE_A, callback=_cb)
+        self.assertEqual(len(_handle_to_channel), before)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Channel.search() builds its own ares_dns_record_t (dnsrec) before submitting the query, and needs to free it exactly once no matter how the call completes. Two bugs meant that didn't happen:

- ares_search_dnsrec() may invoke the callback synchronously before returning a failure status (e.g. RFC 7686 ".onion" rejection). The callback wrapper already destroyed dnsrec in that case, but search()'s own error handling then destroyed it again, causing a double free / segfault.

- If the channel was already closed, _capture_channel() raised before dnsrec was ever handed off to a callback, so nothing freed it at all, leaking the native allocation.

dnsrec is a const parameter to ares_search_dnsrec(), so it is only needed for the duration of that call; free it unconditionally in a single outer finally once the call returns, rather than trying to track which of several paths is responsible for cleanup.

Add regression tests test_search_onion (double free) and test_search_does_not_leak_dnsrec_on_closed_channel (leak).