### PR TITLE
Fix Channel.timeout() returning 0.0 when no queries are pending

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -696,12 +696,12 @@ class Channel:
                 raise ValueError("timeout needs to be a positive number or None")
 
         with self._capture_channel() as channel:
-            _lib.ares_timeout(channel, maxtv, tv)
+            result = _lib.ares_timeout(channel, maxtv, tv)
 
-        if tv == _ffi.NULL:
+        if result == _ffi.NULL:
             return 0.0
 
-        return (tv.tv_sec + tv.tv_usec / 1000000.0)
+        return (result.tv_sec + result.tv_usec / 1000000.0)
 
     def gethostbyaddr(self, addr: str, *, callback: Callable[[Any, int], None]) -> None:
         if not callable(callback):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -743,6 +743,15 @@ class DNSTest(unittest.TestCase):
         self.assertEqual(self.result, None)
         self.assertEqual(self.errorno, pycares.errno.ARES_ECANCELLED)
 
+    def test_channel_timeout_no_pending_queries(self):
+        # Regression test: ares_timeout() only fills in its tv buffer when a
+        # query is actually pending; with none pending it returns maxtv
+        # unchanged. timeout(t) must honor that and return t, not 0.0 (which
+        # event loops interpret as "timeout immediately" and busy-loop on).
+        self.channel = pycares.Channel()
+        self.assertEqual(self.channel.timeout(1.0), 1.0)
+        self.assertEqual(self.channel.timeout(), 0.0)
+
     def test_import_errno(self):
         from pycares.errno import ARES_SUCCESS
 


### PR DESCRIPTION
ares_timeout() returns a pointer to whichever of maxtv/tv actually holds the answer, and only fills in tv when a query is genuinely pending; with none pending it returns maxtv unchanged. The wrapper discarded that return value and always read its own tv buffer, which stays zeroed when nothing is pending, so timeout(t) incorrectly returned 0.0 instead of t.

This caused a real busy-loop in the documented examples/cares-poll.py and examples/cares-selectors.py usage pattern, both of which treat a falsy timeout as "expire immediately" and skip blocking in poll()/ select() entirely.

Add a regression test (test_channel_timeout_no_pending_queries).