### PR TITLE
Fix local IPv6 and device binding

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -878,7 +878,10 @@ class Channel:
             if _lib.ares_inet_pton(socket.AF_INET, ascii_bytes(ip), addr4) == 1:
                 _lib.ares_set_local_ip4(channel, socket.ntohl(addr4.s_addr))
             elif _lib.ares_inet_pton(socket.AF_INET6, ascii_bytes(ip), addr6) == 1:
-                _lib.ares_set_local_ip6(channel, addr6)
+                _lib.ares_set_local_ip6(
+                    channel,
+                    _ffi.cast("unsigned char *", addr6),
+                )
             else:
                 raise ValueError("invalid IP address")
 
@@ -917,7 +920,7 @@ class Channel:
 
     def set_local_dev(self, dev):
         with self._capture_channel() as channel:
-            _lib.ares_set_local_dev(channel, dev)
+            _lib.ares_set_local_dev(channel, ascii_bytes(dev))
 
     def close(self) -> None:
         """

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -742,6 +742,12 @@ class DNSTest(unittest.TestCase):
             )
         self.assertRaises(ValueError, self.channel.set_local_ip, "an invalid ip")
 
+    def test_channel_local_ipv6(self):
+        self.channel.set_local_ip("::1")
+
+    def test_channel_local_dev(self):
+        self.channel.set_local_dev("lo")
+
     def test_channel_timeout(self):
         self.result, self.errorno = None, None
 


### PR DESCRIPTION
Fairly self-explanatory.  Without the fixes, the tests fail with:

> TypeError: initializer for ctype 'char *' must be a bytes or list or tuple, not str

and 

> TypeError: initializer for ctype 'unsigned char *' must be a pointer to same type, not cdata 'struct ares_in6_addr *'
---

Pass IPv6 addresses to c-ares as byte pointers and encode device names before calling the CFFI API.

Add regression tests for both local binding methods.