### PR TITLE
Don't hold the channel lock across c-ares calls

### DIFF
--- a/src/pycares/__init__.py
+++ b/src/pycares/__init__.py
@@ -430,6 +430,37 @@ def parse_dnsrec(dnsrec):
     return result, None
 
 
+class _InFlight:
+    """
+    Counts the threads which are currently inside a c-ares call on a channel.
+
+    A channel must not be destroyed while it is still in use, so the shutdown
+    thread drains the count before destroying it.
+
+    Deliberately holds no reference to the Channel, so that handing it to the
+    shutdown thread doesn't resurrect a Channel which is being finalized.
+    """
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self._count = 0
+
+    def __enter__(self) -> None:
+        with self._cond:
+            self._count += 1
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        with self._cond:
+            self._count -= 1
+            if self._count == 0:
+                self._cond.notify_all()
+
+    def drain(self) -> None:
+        """Block until every call which was in flight has returned."""
+        with self._cond:
+            self._cond.wait_for(lambda: self._count == 0)
+
+
 class _ChannelShutdownManager:
     """Manages channel destruction in a single background thread using SimpleQueue."""
 
@@ -442,11 +473,20 @@ class _ChannelShutdownManager:
         """Process channel destruction requests from the queue."""
         while True:
             # Block forever until we get a channel to destroy
-            ch, _ = self._queue.get()
+            ch, _, calls, waits = self._queue.get()
             channel = ch[0]
 
-            # Cancel all pending queries - this will trigger callbacks with ARES_ECANCELLED
+            # The channel has already been detached, so no new call can start,
+            # but a call which started just before may still be submitting a
+            # query. Let those finish, otherwise a query could be submitted
+            # after the cancellation below and so never complete.
+            calls.drain()
+
+            # Cancel all pending queries - this will trigger callbacks with
+            # ARES_ECANCELLED. It also releases any thread blocked in wait(),
+            # which can then be drained in turn.
             _lib.ares_cancel(channel)
+            waits.drain()
 
             # Wait for all queries to finish
             _lib.ares_queue_wait_empty(channel, -1)
@@ -465,19 +505,20 @@ class _ChannelShutdownManager:
             self._thread = threading.Thread(target=self._run_safe_shutdown_loop, daemon=True)
             self._thread.start()
 
-    def destroy_channel(self, channel, sock_state_cb_handle) -> None:
+    def destroy_channel(self, channel, sock_state_cb_handle, calls: _InFlight, waits: _InFlight) -> None:
         """
         Schedule channel destruction on the background thread.
 
         The socket state callback handle is passed along to ensure it remains
-        alive until the channel is destroyed.
+        alive until the channel is destroyed. The in-flight counters are passed
+        along so that destruction can wait until the channel is unused.
 
         Thread Safety and Synchronization:
         This method uses SimpleQueue which is thread-safe for putting items
         from multiple threads. The background thread processes channels
         sequentially waiting for queries to end before each destruction.
         """
-        self._queue.put((channel, sock_state_cb_handle))
+        self._queue.put((channel, sock_state_cb_handle, calls, waits))
 
 
 # Global shutdown manager instance
@@ -509,7 +550,13 @@ class Channel:
 
         # Initialize _channel to None first to ensure __del__ doesn't fail
         self._channel = None
-        self._lock = threading.RLock()
+        self._lock = threading.Lock()
+
+        # Calls and waits are counted separately because they must be drained
+        # in that order when the channel is destroyed: a call may still submit
+        # a query, whereas a wait only returns once the channel is cancelled.
+        self._calls = _InFlight()
+        self._waits = _InFlight()
 
         # Store flags for later use (default is 0 if not specified)
         self._flags = flags if flags is not None else 0
@@ -612,17 +659,25 @@ class Channel:
         self._destroy_channel()
 
     @contextlib.contextmanager
-    def _capture_channel(self):
+    def _capture_channel(self, in_flight: Optional[_InFlight] = None):
         """
-        Yield the c-ares channel pointer while holding self._lock so that
-        a concurrent close() cannot destroy the channel mid-call.
+        Yield the c-ares channel pointer, counted as in flight so that a
+        concurrent close() cannot destroy the channel mid-call.
+
+        self._lock is only held while reading self._channel: c-ares runs
+        callbacks with its own channel lock held, and such a callback may call
+        back into this Channel from another thread, so holding a Python lock
+        across a c-ares call would invert the two locks.
 
         Raises RuntimeError if the channel has been closed.
         """
-        with self._lock:
-            channel = self._channel
-            if channel is None:
-                raise RuntimeError("Channel is destroyed, no new queries allowed")
+        if in_flight is None:
+            in_flight = self._calls
+        with in_flight:
+            with self._lock:
+                channel = self._channel
+                if channel is None:
+                    raise RuntimeError("Channel is destroyed, no new queries allowed")
             yield channel[0]
 
     def _register_callback_handle(self, callback_data):
@@ -944,7 +999,9 @@ class Channel:
         # query callback.
 
         # Schedule channel destruction
-        _shutdown_manager.destroy_channel(channel, self._sock_state_cb_handle)
+        _shutdown_manager.destroy_channel(
+            channel, self._sock_state_cb_handle, self._calls, self._waits
+        )
 
     def wait(self, timeout: float=None) -> bool:
         """
@@ -953,7 +1010,7 @@ class Channel:
         Args:
             timeout: Maximum time to wait in seconds. Use -1 for infinite wait.
         """
-        with self._capture_channel() as channel:
+        with self._capture_channel(self._waits) as channel:
             r = _lib.ares_queue_wait_empty(channel,  int(timeout * 1000) if timeout is not None and timeout >= 0 else -1)
         if r == _lib.ARES_SUCCESS:
             return True

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -945,7 +945,34 @@ class DNSTest(unittest.TestCase):
             self.assertTrue(type(pycares.errno.strerror(key)), str)
 
 
+_BLOCK_TIMEOUT = 5.0  # generous: only a real deadlock should ever exceed it
+
+
 class ChannelCloseTest(unittest.TestCase):
+    def assertDoesNotBlock(self, func, message):
+        # Run func() on its own thread, so that a call which deadlocks fails
+        # the test rather than hanging it.
+        thread = threading.Thread(target=func, daemon=True)
+        thread.start()
+        thread.join(timeout=_BLOCK_TIMEOUT)
+        self.assertFalse(thread.is_alive(), message)
+
+    def start_wait(self, channel, **kwargs):
+        # Start a thread in channel.wait() and return it with the list which
+        # will collect its result. The thread signals immediately before the
+        # call, so the caller need not sleep for an arbitrary period and hope.
+        entered = threading.Event()
+        result = []
+
+        def wait():
+            entered.set()
+            result.append(channel.wait(**kwargs))
+
+        thread = threading.Thread(target=wait, daemon=True)
+        thread.start()
+        self.assertTrue(entered.wait(timeout=_BLOCK_TIMEOUT), "wait() did not start")
+        return thread, result
+
     def test_close_from_same_thread(self):
         # Test that close() works when called from the same thread
         channel = pycares.Channel()
@@ -1143,6 +1170,90 @@ class ChannelCloseTest(unittest.TestCase):
         self.assertNotIn(
             "can't create new thread at interpreter shutdown", result.stderr
         )
+
+    def test_submit_query_from_callback_while_waiting(self):
+        # A callback must be able to submit a query while another thread is
+        # blocked in wait(), and cancel() must not block behind that wait().
+        channel = pycares.Channel(sock_state_cb=lambda *args: None)
+        self.addCleanup(channel.close)
+        errors = []
+
+        def second_callback(result, error):
+            errors.append(error)
+
+        def first_callback(result, error):
+            errors.append(error)
+            channel.query(
+                "callback-submission.example.invalid",
+                pycares.QUERY_TYPE_A,
+                callback=second_callback,
+            )
+
+        channel.query(
+            "wait-callback-submission.example.invalid",
+            pycares.QUERY_TYPE_A,
+            callback=first_callback,
+        )
+
+        wait_thread, wait_result = self.start_wait(channel, timeout=_BLOCK_TIMEOUT)
+
+        self.assertDoesNotBlock(channel.cancel, "cancel() blocked behind wait()")
+
+        # ares_cancel() only cancels the queries which were outstanding when
+        # it was entered, so the query submitted by first_callback outlives
+        # the cancel that triggered it; cancel again to let the wait complete.
+        channel.cancel()
+        wait_thread.join(timeout=_BLOCK_TIMEOUT)
+
+        self.assertEqual(errors, [pycares.errno.ARES_ECANCELLED] * 2)
+        self.assertEqual(wait_result, [True])
+
+    def test_close_while_waiting(self):
+        # close() must neither block behind an in-flight wait() nor leave it
+        # blocked forever.
+        channel = pycares.Channel(sock_state_cb=lambda *args: None)
+        channel.query(
+            "close-while-waiting.example.invalid",
+            pycares.QUERY_TYPE_A,
+            callback=lambda result, error: None,
+        )
+        wait_thread, wait_result = self.start_wait(channel)
+
+        self.assertDoesNotBlock(channel.close, "close() blocked behind wait()")
+        wait_thread.join(timeout=_BLOCK_TIMEOUT)
+
+        self.assertEqual(wait_result, [True])
+
+    def test_event_thread_callback_can_reenter_channel(self):
+        # Without a sock_state_cb the channel drives itself on c-ares' own
+        # event thread, which is the default configuration. Callbacks then
+        # arrive on that thread while c-ares holds its channel lock, and must
+        # still be able to call back into the Channel while this thread is
+        # blocked in wait().
+        #
+        # The server is unroutable (TEST-NET-1), so the query stays
+        # outstanding until it times out, by which point the waiting thread is
+        # reliably inside wait(). The wait runs on its own thread so that this
+        # inversion is reported as a failure rather than hanging the suite.
+        channel = pycares.Channel(servers=["192.0.2.1"], timeout=0.5, tries=1)
+        self.addCleanup(self.assertDoesNotBlock, channel.close, "close() blocked")
+        reentered = []
+
+        def callback(result, error):
+            reentered.append(channel.timeout())
+
+        channel.query(
+            "event-thread-reentry.example.invalid",
+            pycares.QUERY_TYPE_A,
+            callback=callback,
+        )
+
+        wait_thread, wait_result = self.start_wait(channel, timeout=_BLOCK_TIMEOUT)
+        wait_thread.join(timeout=_BLOCK_TIMEOUT * 2)
+
+        self.assertFalse(wait_thread.is_alive(), "wait() deadlocked against callback")
+        self.assertEqual(wait_result, [True])
+        self.assertEqual(len(reentered), 1)
 
     def test_concurrent_close_multiple_channels(self):
         # Test multiple channels being closed concurrently


### PR DESCRIPTION
I do not love how complicated it is getting to avoid use-after-free and deadlock at shutdown etc; but I see no obvious simplification.

---

c-ares runs callbacks with its own channel lock held, and a callback may call back into the Channel from another thread. So holding the Python lock across a c-ares call can deadlock: a thread in wait() held the lock until the query queue drained, but draining it needed a callback which wanted the same lock.

Hold the lock only while reading self._channel, and count the calls in flight instead, so that the shutdown thread can wait for the channel to fall idle before destroying it. Calls and waits are counted separately because they have to be drained either side of the cancel: a call may still submit a query, whereas a wait only returns once the cancel has happened.